### PR TITLE
Modification vote "Nouvelle Calédonie"

### DIFF
--- a/data/votes/VTANR5L16V3725.json
+++ b/data/votes/VTANR5L16V3725.json
@@ -1,7 +1,6 @@
 {
   "titre": "Réformer le corps électoral en Nouvelle-Calédonie",
   "sous_titre_1": "Ouvrir le vote aux élections locales aux natifs et aux personnes ayant au moins 10 ans de résidence",
-  "sous_titre_2": "Revient sur l'Accord de Nouméa de 1998 qui accordait la priorité au peuple autochtone Kanak",
   "summary_url": "https://www.senat.fr/travaux-parlementaires/textes-legislatifs/la-loi-en-clair/projet-de-loi-constitutionnelle-portant-modification-du-corps-electoral-pour-les-elections-au-congres-et-aux-assemblees-de-province-de-la-nouvelle-caledonie.html",
   "dossier_url": "http://www.senat.fr/dossier-legislatif/pjl23-291.html",
   "pinned": true,

--- a/data/votes/VTANR5L16V3725.json
+++ b/data/votes/VTANR5L16V3725.json
@@ -1,6 +1,7 @@
 {
   "titre": "Réformer le corps électoral en Nouvelle-Calédonie",
   "sous_titre_1": "Ouvrir le vote aux élections locales aux natifs et aux personnes ayant au moins 10 ans de résidence",
+  "sous_titre_2": "Mettre fin au gel du corps électoral suite à la tenue des référendums d'autodétermination",
   "summary_url": "https://www.senat.fr/travaux-parlementaires/textes-legislatifs/la-loi-en-clair/projet-de-loi-constitutionnelle-portant-modification-du-corps-electoral-pour-les-elections-au-congres-et-aux-assemblees-de-province-de-la-nouvelle-caledonie.html",
   "dossier_url": "http://www.senat.fr/dossier-legislatif/pjl23-291.html",
   "pinned": true,


### PR DESCRIPTION
En référence à https://github.com/arnaudsm/votefinder.fr/issues/31

- Le texte n'indique en rien revenir sur l'accord de Nouméa
- Seule l'information du `sous_titre_1` semble pertinente à conserver, car le texte n'indique pas d'autres mesures "phares" que cette dernière 