### PR TITLE
Modification vote "Occupation illicile"

### DIFF
--- a/data/votes/VTANR5L16V1361.json
+++ b/data/votes/VTANR5L16V1361.json
@@ -1,6 +1,6 @@
 {
-  "titre": "Durcir les sanctions contre le squat",
-  "sous_titre_1": "Élargir les sanctions déjà prévues à 3 ans de prison et 45 000€ d'amende",
+  "titre": "Durcir les sanctions contre l'occupation illicite",
+  "sous_titre_1": "Porter à 3 ans de prison et 45 000€ d'amende l'intrusion et la résidence dans le domicile d'autrui",
   "sous_titre_2": "Créer un délit pour les locataires en impayés de loyer",
   "summary_url": "https://www.senat.fr/travaux-parlementaires/textes-legislatifs/la-loi-en-clair/proposition-de-loi-visant-a-proteger-les-logements-contre-loccupation-illicite.html",
   "dossier_url": "http://www.senat.fr/dossier-legislatif/ppl22-174.html",


### PR DESCRIPTION
- Utilisation du terme "occupation illicite" plutôt que "squat", qui a une conotation bien plus neutre et formelle
- Précision du `sous_titre_1` (car il faut distinguer occupattion de local et occupation de domicile d'autrui)