### PR TITLE
:lipstick: Votes : prevent overflow on card reverse, improve progress bar z-index

### DIFF
--- a/frontend/src/assets/styles/pages/_Votes.scss
+++ b/frontend/src/assets/styles/pages/_Votes.scss
@@ -1,14 +1,21 @@
 @use '../base/breakpoints' as breakpoints;
 
 .Votes {
-  padding: 1.75rem 1rem 1.5rem;
-  box-sizing: border-box;
+  max-width: unset;
   height: 100%;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: space-between;
+  overflow: hidden;
+
+  &__container {
+    padding: 1.75rem 1rem 1.5rem;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+    max-width: 30rem;
+    margin: 0 auto;
+  }
 
   &__bg-color {
     position: absolute;
@@ -149,6 +156,7 @@
     height: 0.5rem;
     width: 100%;
     background-color: var(--vote-progress-color);
+    z-index: 5;
 
     .progress {
       &__bar {

--- a/frontend/src/pages/Votes.jsx
+++ b/frontend/src/pages/Votes.jsx
@@ -156,100 +156,104 @@ export default function Votes() {
 
   return (
     <div className={`Votes`}>
-      {progress < 100 && (
-        <div className="Votes__progress progress">
-          <div
-            className="progress__bar"
-            style={{ width: `${progress}%` }}
-          ></div>
+      <div className="Votes__container">
+        {progress < 100 && (
+          <div className="Votes__progress progress">
+            <div
+              className="progress__bar"
+              style={{ width: `${progress}%` }}
+            ></div>
+          </div>
+        )}
+
+        <div className="Votes__bg-color"></div>
+        <div className="Votes__bg-circle"></div>
+
+        <Stack className="Votes__stack">
+          <CardSwiper
+            className="Votes__card-swiper"
+            data={cardData}
+            onEnter={handleEnter}
+            onFinish={() => null}
+            onDismiss={handleDismiss}
+            dislikeButton={<div />}
+            likeButton={<div />}
+            withActionButtons
+            withRibbons
+            likeRibbonText="POUR"
+            dislikeRibbonText="CONTRE"
+            ribbonColors={{
+              bgLike: "var(--mui-palette-green-main)",
+              bgDislike: "var(--mui-palette-red-main)",
+              textColor: "white",
+            }}
+            emptyState={<NoVotesLeft />}
+          />
+        </Stack>
+        <div className="Votes__actions actions">
+          <Button
+            disableElevation
+            className="actions__contre"
+            ref={actionContreRef}
+            onClick={() => {
+              if (canPressActionRef.current === false) return;
+
+              delayNextActionPress();
+
+              document
+                .getElementById("swipe-card__dislike-action-button")
+                ?.click();
+
+              setTimeout(() => {
+                context.choose({ vote_id: id, type: "-" });
+              }, 0);
+            }}
+          >
+            <ThumbDownIcon color="red" />
+          </Button>
+
+          <Button
+            disableElevation
+            className="actions__passer"
+            ref={actionPasserRef}
+            onClick={() => {
+              if (canPressActionRef.current === false) return;
+
+              delayNextActionPress();
+
+              document
+                .getElementById("swipe-card__dislike-action-button")
+                ?.click();
+
+              setTimeout(() => {
+                context.choose({ vote_id: id, type: "0" });
+              }, 0);
+            }}
+          >
+            <CrossIcon />
+          </Button>
+
+          <Button
+            disableElevation
+            className="actions__pour"
+            ref={actionPourRef}
+            onClick={() => {
+              if (canPressActionRef.current === false) return;
+
+              delayNextActionPress();
+
+              document
+                .getElementById("swipe-card__like-action-button")
+                ?.click();
+
+              setTimeout(() => {
+                context.choose({ vote_id: id, type: "+" });
+              }, 0);
+            }}
+          >
+            <ThumbUpIcon color="green" />
+          </Button>
         </div>
-      )}
-
-      <div className="Votes__bg-color"></div>
-      <div className="Votes__bg-circle"></div>
-
-      <Stack className="Votes__stack">
-        <CardSwiper
-          className="Votes__card-swiper"
-          data={cardData}
-          onEnter={handleEnter}
-          onFinish={() => null}
-          onDismiss={handleDismiss}
-          dislikeButton={<div />}
-          likeButton={<div />}
-          withActionButtons
-          withRibbons
-          likeRibbonText="POUR"
-          dislikeRibbonText="CONTRE"
-          ribbonColors={{
-            bgLike: "var(--mui-palette-green-main)",
-            bgDislike: "var(--mui-palette-red-main)",
-            textColor: "white",
-          }}
-          emptyState={<NoVotesLeft />}
-        />
-      </Stack>
-      <div className="Votes__actions actions">
-        <Button
-          disableElevation
-          className="actions__contre"
-          ref={actionContreRef}
-          onClick={() => {
-            if (canPressActionRef.current === false) return;
-
-            delayNextActionPress();
-
-            document
-              .getElementById("swipe-card__dislike-action-button")
-              ?.click();
-
-            setTimeout(() => {
-              context.choose({ vote_id: id, type: "-" });
-            }, 0);
-          }}
-        >
-          <ThumbDownIcon color="red" />
-        </Button>
-
-        <Button
-          disableElevation
-          className="actions__passer"
-          ref={actionPasserRef}
-          onClick={() => {
-            if (canPressActionRef.current === false) return;
-
-            delayNextActionPress();
-
-            document
-              .getElementById("swipe-card__dislike-action-button")
-              ?.click();
-
-            setTimeout(() => {
-              context.choose({ vote_id: id, type: "0" });
-            }, 0);
-          }}
-        >
-          <CrossIcon />
-        </Button>
-
-        <Button
-          disableElevation
-          className="actions__pour"
-          ref={actionPourRef}
-          onClick={() => {
-            if (canPressActionRef.current === false) return;
-
-            delayNextActionPress();
-
-            document.getElementById("swipe-card__like-action-button")?.click();
-
-            setTimeout(() => {
-              context.choose({ vote_id: id, type: "+" });
-            }, 0);
-          }}
-        >
-          <ThumbUpIcon color="green" />
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
- Dans certains cas (notamment sur grand écran), le fait de retourner une carte peut créer un overflow scroll, et donc afficher la barre de scroll sur le côté (celle qui a été supprimée hier !). Avec cette modif je rajoute un container pour supprimer l'overflow uniquement sur cette page .
- Augmentation du z-index de la progress bar, idem pour qu'une carte ne passe pas devant lorsqu'on la tourne