### PR TITLE
Restorer le classement des députés

### DIFF
--- a/frontend/src/components/ResultsDeputes.jsx
+++ b/frontend/src/components/ResultsDeputes.jsx
@@ -17,20 +17,13 @@ export default function ResultsDeputes({ results }) {
   };
 
   const deputesVotesSort = ([id_a], [id_b]) => {
-    const ratio_a = getRatio(id_a);
-    const ratio_b = getRatio(id_b);
-
-    if (ratio_a === ratio_b) {
-      const sum_a =
-        (results?.deputesRaw?.[id_a]?.["+"] || 0) +
-        (results?.deputesRaw?.[id_a]?.["-"] || 0);
-      const sum_b =
-        (results?.deputesRaw?.[id_b]?.["+"] || 0) +
-        (results?.deputesRaw?.[id_b]?.["-"] || 0);
-      return sum_b - sum_a;
-    }
-
-    return 0;
+    const sum_a =
+      (results?.deputesRaw?.[id_a]?.["+"] || 0) +
+      (results?.deputesRaw?.[id_a]?.["-"] || 0);
+    const sum_b =
+      (results?.deputesRaw?.[id_b]?.["+"] || 0) +
+      (results?.deputesRaw?.[id_b]?.["-"] || 0);
+    return sum_b - sum_a;
   };
 
   return (


### PR DESCRIPTION
@Striffly je propose de retourner à l'algo de classement que tu avais modifié

La version actuelle a un énorme biais : elle met en avant les députés qui ne votent jamais mais ont été d'accord une seule fois : 
![image](https://github.com/arnaudsm/votefinder.fr/assets/3920793/353185c9-0f5f-4ac7-8a15-f9bd2b32e898)
De plus, la légende est fausse, elle ment sur la méthode de classement.

L'ancienne version n'avait pas ce problème, je propose d'y revenir.
Mieux vaut discuter ensemble ce genre de changement important