### PR TITLE
Procons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ legacy
 .env
 data/sync.js
 data/resumes
+data/amendements
 
 # Logs
 logs

--- a/data/amendement_urls.json
+++ b/data/amendement_urls.json
@@ -2,14096 +2,16915 @@
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000043",
         "vote_id": "10",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/5626": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N005626",
         "vote_id": "1000",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3132": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003132",
         "vote_id": "1001",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3125": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003125",
         "vote_id": "1002",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/20118": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N020118",
         "vote_id": "1003",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4592": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004592",
         "vote_id": "1004",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4596": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004596",
         "vote_id": "1005",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3118": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003118",
         "vote_id": "1006",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1018": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001018",
         "vote_id": "1007",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3606": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003606",
         "vote_id": "1008",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/6655": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N006655",
         "vote_id": "1009",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3451": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003451",
         "vote_id": "1010",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3452": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003452",
         "vote_id": "1011",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4723": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004723",
         "vote_id": "1012",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/18838": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N018838",
         "vote_id": "1013",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26797"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2392": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002392",
         "vote_id": "1014",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26798"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/5754": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N005754",
         "vote_id": "1015",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26798"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19574": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019574",
         "vote_id": "1016",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26798"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1659": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001659",
         "vote_id": "1017",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26798"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19151": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019151",
         "vote_id": "1018",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26802"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1808": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001808",
         "vote_id": "1019",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26802"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16663": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016663",
         "vote_id": "1020",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26802"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1658": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001658",
         "vote_id": "1021",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26802"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3178": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003178",
         "vote_id": "1022",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3295": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003295",
         "vote_id": "1023",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3179": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003179",
         "vote_id": "1024",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3184": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003184",
         "vote_id": "1025",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3180": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003180",
         "vote_id": "1026",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3185": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003185",
         "vote_id": "1027",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3181": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003181",
         "vote_id": "1028",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3249": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003249",
         "vote_id": "1029",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3182": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003182",
         "vote_id": "1030",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3183": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003183",
         "vote_id": "1031",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3252": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003252",
         "vote_id": "1032",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3186": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003186",
         "vote_id": "1033",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/6491": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N006491",
         "vote_id": "1034",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3187": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003187",
         "vote_id": "1035",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3296": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003296",
         "vote_id": "1036",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3257": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003257",
         "vote_id": "1037",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3188": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003188",
         "vote_id": "1038",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3299": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003299",
         "vote_id": "1039",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3189": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003189",
         "vote_id": "1040",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3300": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003300",
         "vote_id": "1041",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3190": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003190",
         "vote_id": "1042",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3301": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003301",
         "vote_id": "1043",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3191": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003191",
         "vote_id": "1044",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3302": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003302",
         "vote_id": "1045",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3192": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003192",
         "vote_id": "1046",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3303": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003303",
         "vote_id": "1047",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3193": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003193",
         "vote_id": "1048",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3304": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003304",
         "vote_id": "1049",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3194": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003194",
         "vote_id": "1050",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3305": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003305",
         "vote_id": "1051",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3266": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003266",
         "vote_id": "1052",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3509": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003509",
         "vote_id": "1053",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3267": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003267",
         "vote_id": "1054",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3506": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003506",
         "vote_id": "1055",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3268": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003268",
         "vote_id": "1056",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3195": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003195",
         "vote_id": "1057",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3269": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003269",
         "vote_id": "1058",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3504": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003504",
         "vote_id": "1059",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3270": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003270",
         "vote_id": "1060",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3503": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003503",
         "vote_id": "1061",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3196": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003196",
         "vote_id": "1062",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3502": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003502",
         "vote_id": "1063",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3197": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003197",
         "vote_id": "1064",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3501": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003501",
         "vote_id": "1065",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3198": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003198",
         "vote_id": "1066",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3500": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003500",
         "vote_id": "1067",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3199": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003199",
         "vote_id": "1068",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3499": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003499",
         "vote_id": "1069",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3200": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003200",
         "vote_id": "1070",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3495": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003495",
         "vote_id": "1071",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3279": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003279",
         "vote_id": "1072",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3494": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003494",
         "vote_id": "1073",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3280": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003280",
         "vote_id": "1074",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3493": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003493",
         "vote_id": "1075",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3281": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003281",
         "vote_id": "1076",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3282": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003282",
         "vote_id": "1077",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3491": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003491",
         "vote_id": "1078",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3283": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003283",
         "vote_id": "1079",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/6519": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N006519",
         "vote_id": "1080",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3284": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003284",
         "vote_id": "1081",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3489": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003489",
         "vote_id": "1082",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3483": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003483",
         "vote_id": "1083",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3291": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003291",
         "vote_id": "1084",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3482": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003482",
         "vote_id": "1085",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1646": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001646",
         "vote_id": "1086",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3481": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003481",
         "vote_id": "1087",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3293": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003293",
         "vote_id": "1088",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3480": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003480",
         "vote_id": "1089",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3294": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003294",
         "vote_id": "1090",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3479": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003479",
         "vote_id": "1091",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26803"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16608": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016608",
         "vote_id": "1092",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26804"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1537": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001537",
         "vote_id": "1093",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26804"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/329": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000329",
         "vote_id": "1094",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26804"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2808": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002808",
         "vote_id": "1095",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26804"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2809": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002809",
         "vote_id": "1096",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26804"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000061",
         "vote_id": "11",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0740/AN/50": {
         "amendement_id": "AMANR5L16PO791932B0740P0D1N000050",
         "vote_id": "1100",
-        "dossier_id": "DLR5L16N47036"
+        "dossier_id": "DLR5L16N47036",
+        "seance_id": "RUANR5L16S2023IDS26844"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0740/AN/49": {
         "amendement_id": "AMANR5L16PO791932B0740P0D1N000049",
         "vote_id": "1101",
-        "dossier_id": "DLR5L16N47036"
+        "dossier_id": "DLR5L16N47036",
+        "seance_id": "RUANR5L16S2023IDS26844"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0740/AN/165": {
         "amendement_id": "AMANR5L16PO791932B0740P0D1N000165",
         "vote_id": "1102",
-        "dossier_id": "DLR5L16N47036"
+        "dossier_id": "DLR5L16N47036",
+        "seance_id": "RUANR5L16S2023IDS26844"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0740/AN/153": {
         "amendement_id": "AMANR5L16PO791932B0740P0D1N000153",
         "vote_id": "1103",
-        "dossier_id": "DLR5L16N47036"
+        "dossier_id": "DLR5L16N47036",
+        "seance_id": "RUANR5L16S2023IDS26844"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0740/AN/150": {
         "amendement_id": "AMANR5L16PO791932B0740P0D1N000150",
         "vote_id": "1104",
-        "dossier_id": "DLR5L16N47036"
+        "dossier_id": "DLR5L16N47036",
+        "seance_id": "RUANR5L16S2023IDS26844"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0859/AN/51": {
         "amendement_id": "AMANR5L16PO791932BTC0859P0D1N000051",
         "vote_id": "1106",
-        "dossier_id": "DLR5L16N47035"
+        "dossier_id": "DLR5L16N47035",
+        "seance_id": "RUANR5L16S2023IDS26845"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0859/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC0859P0D1N000062",
         "vote_id": "1107",
-        "dossier_id": "DLR5L16N47035"
+        "dossier_id": "DLR5L16N47035",
+        "seance_id": "RUANR5L16S2023IDS26845"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0861/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC0861P0D1N000021",
         "vote_id": "1109",
-        "dossier_id": "DLR5L16N47037"
+        "dossier_id": "DLR5L16N47037",
+        "seance_id": "RUANR5L16S2023IDS26846"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0861/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC0861P0D1N000023",
         "vote_id": "1110",
-        "dossier_id": "DLR5L16N47037"
+        "dossier_id": "DLR5L16N47037",
+        "seance_id": "RUANR5L16S2023IDS26846"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0861/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC0861P0D1N000024",
         "vote_id": "1111",
-        "dossier_id": "DLR5L16N47037"
+        "dossier_id": "DLR5L16N47037",
+        "seance_id": "RUANR5L16S2023IDS26846"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0861/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC0861P0D1N000039",
         "vote_id": "1112",
-        "dossier_id": "DLR5L16N47037"
+        "dossier_id": "DLR5L16N47037",
+        "seance_id": "RUANR5L16S2023IDS26846"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0861/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC0861P0D1N000033",
         "vote_id": "1113",
-        "dossier_id": "DLR5L16N47037"
+        "dossier_id": "DLR5L16N47037",
+        "seance_id": "RUANR5L16S2023IDS26846"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0908/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC0908P0D1N000014",
         "vote_id": "1115",
-        "dossier_id": "DLR5L16N47047"
+        "dossier_id": "DLR5L16N47047",
+        "seance_id": "RUANR5L16S2023IDS26857"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0908/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC0908P0D1N000008",
         "vote_id": "1118",
-        "dossier_id": "DLR5L16N47047"
+        "dossier_id": "DLR5L16N47047",
+        "seance_id": "RUANR5L16S2023IDS26857"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/69": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000069",
         "vote_id": "1120",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000012",
         "vote_id": "1121",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000011",
         "vote_id": "1122",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000096",
         "vote_id": "1123",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000040",
         "vote_id": "1124",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000015",
         "vote_id": "1125",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26858"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0906/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC0906P0D1N000001",
         "vote_id": "1126",
-        "dossier_id": "DLR5L16N47056"
+        "dossier_id": "DLR5L16N47056",
+        "seance_id": "RUANR5L16S2023IDS26859"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0906/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC0906P0D1N000004",
         "vote_id": "1127",
-        "dossier_id": "DLR5L16N47056"
+        "dossier_id": "DLR5L16N47056",
+        "seance_id": "RUANR5L16S2023IDS26859"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000016",
         "vote_id": "1130",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000017",
         "vote_id": "1131",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000018",
         "vote_id": "1132",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000057",
         "vote_id": "1133",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000043",
         "vote_id": "1134",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000095",
         "vote_id": "1135",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/102": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000102",
         "vote_id": "1136",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000006",
         "vote_id": "1138",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000005",
         "vote_id": "1139",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0909/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC0909P0D1N000049",
         "vote_id": "1140",
-        "dossier_id": "DLR5L16N47046"
+        "dossier_id": "DLR5L16N47046",
+        "seance_id": "RUANR5L16S2023IDS26860"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0862/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC0862P0D1N000054",
         "vote_id": "1142",
-        "dossier_id": "DLR5L16N46888"
+        "dossier_id": "DLR5L16N46888",
+        "seance_id": "RUANR5L16S2023IDS26861"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0862/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC0862P0D1N000002",
         "vote_id": "1143",
-        "dossier_id": "DLR5L16N46888"
+        "dossier_id": "DLR5L16N46888",
+        "seance_id": "RUANR5L16S2023IDS26861"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000048",
         "vote_id": "1145",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000001",
         "vote_id": "1146",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000007",
         "vote_id": "1147",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000018",
         "vote_id": "1148",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000017",
         "vote_id": "1149",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000006",
         "vote_id": "1150",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000019",
         "vote_id": "1151",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000042",
         "vote_id": "1152",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000043",
         "vote_id": "1153",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0912/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC0912P0D1N000044",
         "vote_id": "1154",
-        "dossier_id": "DLR5L16N47015"
+        "dossier_id": "DLR5L16N47015",
+        "seance_id": "RUANR5L16S2023IDS26863"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/327": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000327",
         "vote_id": "1158",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26877"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/426": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000426",
         "vote_id": "1160",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26877"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/343": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000343",
         "vote_id": "1161",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26877"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/165": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000165",
         "vote_id": "1162",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000020",
         "vote_id": "1163",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000038",
         "vote_id": "1164",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/611": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000611",
         "vote_id": "1166",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/334": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000334",
         "vote_id": "1168",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/610": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000610",
         "vote_id": "1169",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/333": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000333",
         "vote_id": "1170",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/558": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000558",
         "vote_id": "1171",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/348": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000348",
         "vote_id": "1172",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/158": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000158",
         "vote_id": "1173",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/580": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000580",
         "vote_id": "1174",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/338": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000338",
         "vote_id": "1175",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26878"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/475": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000475",
         "vote_id": "1176",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/249": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000249",
         "vote_id": "1177",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/579": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000579",
         "vote_id": "1178",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/655": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000655",
         "vote_id": "1179",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/211": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000211",
         "vote_id": "1180",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/223": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000223",
         "vote_id": "1181",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26879"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/310": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000310",
         "vote_id": "1182",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/351": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000351",
         "vote_id": "1183",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/510": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000510",
         "vote_id": "1184",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/591": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000591",
         "vote_id": "1185",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000075",
         "vote_id": "1187",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/407": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000407",
         "vote_id": "1188",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/468": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000468",
         "vote_id": "1189",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/196": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000196",
         "vote_id": "1192",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/200": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000200",
         "vote_id": "1193",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/509": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000509",
         "vote_id": "1194",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/516": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000516",
         "vote_id": "1195",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26880"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/672": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000672",
         "vote_id": "1199",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26881"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000059",
         "vote_id": "12",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/419": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000419",
         "vote_id": "1202",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26881"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/588": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000588",
         "vote_id": "1203",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26881"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/398": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000398",
         "vote_id": "1204",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26882"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/615": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000615",
         "vote_id": "1206",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26882"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/435": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000435",
         "vote_id": "1208",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26882"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/236": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000236",
         "vote_id": "1212",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/639": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000639",
         "vote_id": "1215",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000001",
         "vote_id": "1216",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/195": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000195",
         "vote_id": "1219",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/724": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000724",
         "vote_id": "1220",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/366": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000366",
         "vote_id": "1221",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26883"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/744": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000744",
         "vote_id": "1222",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26893"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/623": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000623",
         "vote_id": "1223",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26893"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/472": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000472",
         "vote_id": "1224",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26893"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000093",
         "vote_id": "1226",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26893"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/682": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000682",
         "vote_id": "1227",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26893"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1099": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001099",
         "vote_id": "123",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26213"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/281": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000281",
         "vote_id": "1233",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/633": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000633",
         "vote_id": "1234",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/513": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000513",
         "vote_id": "1235",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/576": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000576",
         "vote_id": "1236",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000046",
         "vote_id": "1237",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/363": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000363",
         "vote_id": "1238",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0917/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC0917P0D1N000044",
         "vote_id": "1239",
-        "dossier_id": "DLR5L16N46622"
+        "dossier_id": "DLR5L16N46622",
+        "seance_id": "RUANR5L16S2023IDS26894"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000015",
         "vote_id": "1244",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26886"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/628": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000628",
         "vote_id": "1245",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/627": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000627",
         "vote_id": "1246",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000049",
         "vote_id": "1247",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/92": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000092",
         "vote_id": "1249",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/482": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000482",
         "vote_id": "1250",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/446": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000446",
         "vote_id": "1252",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26887"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/760": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000760",
         "vote_id": "1256",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26888"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/340": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000340",
         "vote_id": "126",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26213"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/772": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000772",
         "vote_id": "1260",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26888"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000044",
         "vote_id": "1261",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26888"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/148": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000148",
         "vote_id": "1264",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26889"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/563": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000563",
         "vote_id": "1265",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26889"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/406": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000406",
         "vote_id": "1266",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26889"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/217": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000217",
         "vote_id": "1267",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26889"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/153": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000153",
         "vote_id": "1268",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/789": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000789",
         "vote_id": "1269",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/603": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000603",
         "vote_id": "127",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/757": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000757",
         "vote_id": "1270",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/509": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000509",
         "vote_id": "1271",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000056",
         "vote_id": "1272",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000070",
         "vote_id": "1273",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26890"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/127": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000127",
         "vote_id": "1279",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26891"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1116": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001116",
         "vote_id": "128",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/649": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000649",
         "vote_id": "1282",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26891"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/588": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000588",
         "vote_id": "1283",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26891"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/647": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000647",
         "vote_id": "129",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/670": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000670",
         "vote_id": "1290",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26892"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/248": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000248",
         "vote_id": "1291",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26892"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0939/AN/136": {
         "amendement_id": "AMANR5L16PO791932BTC0939P0D1N000136",
         "vote_id": "1292",
-        "dossier_id": "DLR5L16N46918"
+        "dossier_id": "DLR5L16N46918",
+        "seance_id": "RUANR5L16S2023IDS26892"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000005",
         "vote_id": "1299",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1082": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001082",
         "vote_id": "130",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000035",
         "vote_id": "1300",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000001",
         "vote_id": "1301",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000021",
         "vote_id": "1302",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000014",
         "vote_id": "1303",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000019",
         "vote_id": "1304",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26938"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000052",
         "vote_id": "1307",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26940"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000059",
         "vote_id": "1309",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26940"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/271": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000271",
         "vote_id": "131",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000020",
         "vote_id": "1310",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26940"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000012",
         "vote_id": "1311",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26941"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1005/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1005P0D1N000026",
         "vote_id": "1312",
-        "dossier_id": "DLR5L16N47089"
+        "dossier_id": "DLR5L16N47089",
+        "seance_id": "RUANR5L16S2023IDS26941"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/146": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000146",
         "vote_id": "1318",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/37": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000037",
         "vote_id": "1319",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/995": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000995",
         "vote_id": "132",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/105": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000105",
         "vote_id": "1320",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/101": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000101",
         "vote_id": "1321",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/102": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000102",
         "vote_id": "1322",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/103": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000103",
         "vote_id": "1323",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000008",
         "vote_id": "1324",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000009",
         "vote_id": "1325",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26942"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/831": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000831",
         "vote_id": "133",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1010/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1010P0D1N000007",
         "vote_id": "1337",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26943"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1096": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001096",
         "vote_id": "134",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000039",
         "vote_id": "1341",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000096",
         "vote_id": "1342",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/184": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000184",
         "vote_id": "1344",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/176": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000176",
         "vote_id": "1345",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/123": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000123",
         "vote_id": "1346",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000047",
         "vote_id": "1347",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26944"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000054",
         "vote_id": "1348",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000095",
         "vote_id": "1349",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/185": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000185",
         "vote_id": "135",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/87": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000087",
         "vote_id": "1350",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000040",
         "vote_id": "1352",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000044",
         "vote_id": "1353",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/108": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000108",
         "vote_id": "1355",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/132": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000132",
         "vote_id": "1356",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000111",
         "vote_id": "1357",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/89": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000089",
         "vote_id": "1358",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1006/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC1006P0D1N000093",
         "vote_id": "1359",
-        "dossier_id": "DLR5L16N47074"
+        "dossier_id": "DLR5L16N47074",
+        "seance_id": "RUANR5L16S2023IDS26945"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/483": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000483",
         "vote_id": "136",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000016",
         "vote_id": "1362",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/103": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000103",
         "vote_id": "1363",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/104": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000104",
         "vote_id": "1364",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/102": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000102",
         "vote_id": "1365",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000094",
         "vote_id": "1366",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000010",
         "vote_id": "1367",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000049",
         "vote_id": "1368",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000023",
         "vote_id": "1369",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/535": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000535",
         "vote_id": "137",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000047",
         "vote_id": "1370",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/98": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000098",
         "vote_id": "1371",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000062",
         "vote_id": "1372",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/90": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000090",
         "vote_id": "1373",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000067",
         "vote_id": "1374",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000018",
         "vote_id": "1375",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/107": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000107",
         "vote_id": "1376",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000006",
         "vote_id": "1377",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/91": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000091",
         "vote_id": "1378",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26966"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000056",
         "vote_id": "1379",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1065": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001065",
         "vote_id": "138",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000008",
         "vote_id": "1380",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000055",
         "vote_id": "1381",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/60": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000060",
         "vote_id": "1390",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000009",
         "vote_id": "1383",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000024",
         "vote_id": "1384",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000004",
         "vote_id": "1385",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1019/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1019P0D1N000043",
         "vote_id": "1386",
-        "dossier_id": "DLR5L16N47218"
+        "dossier_id": "DLR5L16N47218",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/58": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000058",
         "vote_id": "1389",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/533": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000533",
         "vote_id": "139",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000049",
         "vote_id": "1392",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000068",
         "vote_id": "1393",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000070",
         "vote_id": "1394",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000038",
         "vote_id": "1395",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/79": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000079",
         "vote_id": "1396",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000061",
         "vote_id": "1397",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000062",
         "vote_id": "1398",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000063",
         "vote_id": "1399",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000067",
         "vote_id": "14",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/188": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000188",
         "vote_id": "140",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1022/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1022P0D1N000023",
         "vote_id": "1401",
-        "dossier_id": "DLR5L16N47217"
+        "dossier_id": "DLR5L16N47217",
+        "seance_id": "RUANR5L16S2023IDS26967"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0885/AN/51": {
         "amendement_id": "AMANR5L16PO791932B0885P0D1N000051",
         "vote_id": "1404",
-        "dossier_id": "DLR5L16N47215"
+        "dossier_id": "DLR5L16N47215",
+        "seance_id": "RUANR5L16S2023IDS26968"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0885/AN/43": {
         "amendement_id": "AMANR5L16PO791932B0885P0D1N000043",
         "vote_id": "1405",
-        "dossier_id": "DLR5L16N47215"
+        "dossier_id": "DLR5L16N47215",
+        "seance_id": "RUANR5L16S2023IDS26968"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0885/AN/45": {
         "amendement_id": "AMANR5L16PO791932B0885P0D1N000045",
         "vote_id": "1406",
-        "dossier_id": "DLR5L16N47215"
+        "dossier_id": "DLR5L16N47215",
+        "seance_id": "RUANR5L16S2023IDS26968"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0885/AN/44": {
         "amendement_id": "AMANR5L16PO791932B0885P0D1N000044",
         "vote_id": "1407",
-        "dossier_id": "DLR5L16N47215"
+        "dossier_id": "DLR5L16N47215",
+        "seance_id": "RUANR5L16S2023IDS26968"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/377": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000377",
         "vote_id": "141",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000015",
         "vote_id": "1414",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS26999"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/909": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000909",
         "vote_id": "1415",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS26999"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/866": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000866",
         "vote_id": "1416",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS26999"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/385": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000385",
         "vote_id": "1417",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS26999"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/220": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000220",
         "vote_id": "1419",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS26999"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/276": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000276",
         "vote_id": "142",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1247": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001247",
         "vote_id": "1420",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27000"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000018",
         "vote_id": "1421",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27000"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000016",
         "vote_id": "1422",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27000"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1277": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001277",
         "vote_id": "1423",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27000"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/122": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000122",
         "vote_id": "1424",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27001"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/76": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000076",
         "vote_id": "1426",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27001"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1167": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001167",
         "vote_id": "1427",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27001"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/87": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000087",
         "vote_id": "1428",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/881": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000881",
         "vote_id": "1429",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/563": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000563",
         "vote_id": "143",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/885": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000885",
         "vote_id": "1430",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1099": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001099",
         "vote_id": "1432",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/532": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000532",
         "vote_id": "1433",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/796": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000796",
         "vote_id": "1434",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/959": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000959",
         "vote_id": "1435",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/638": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000638",
         "vote_id": "1436",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/992": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000992",
         "vote_id": "1437",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/826": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000826",
         "vote_id": "144",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/299": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000299",
         "vote_id": "1440",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/140": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000140",
         "vote_id": "1441",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/310": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000310",
         "vote_id": "1442",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/670": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000670",
         "vote_id": "1443",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/298": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000298",
         "vote_id": "1444",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27002"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1005": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001005",
         "vote_id": "1447",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2023IDS27003"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/933": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000933",
         "vote_id": "145",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0991/AN/9": {
         "amendement_id": "AMANR5L16PO791932B0991P0D1N000009",
         "vote_id": "1458",
-        "dossier_id": "DLR5L16N47411"
+        "dossier_id": "DLR5L16N47411",
+        "seance_id": "RUANR5L16S2023IDS27022"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/84": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000084",
         "vote_id": "146",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000021",
         "vote_id": "1465",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000022",
         "vote_id": "1466",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000062",
         "vote_id": "1467",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000042",
         "vote_id": "1468",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000023",
         "vote_id": "1469",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/804": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000804",
         "vote_id": "147",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000033",
         "vote_id": "1470",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000040",
         "vote_id": "1471",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000006",
         "vote_id": "1474",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000008",
         "vote_id": "1475",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000048",
         "vote_id": "1476",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000026",
         "vote_id": "1477",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000035",
         "vote_id": "1478",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/50": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000050",
         "vote_id": "1479",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/281": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000281",
         "vote_id": "148",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1090/AN/51": {
         "amendement_id": "AMANR5L16PO791932BTC1090P0D1N000051",
         "vote_id": "1480",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2023IDS27023"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/37": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000037",
         "vote_id": "1486",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27038"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/41": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000041",
         "vote_id": "1487",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27038"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1181/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1181P0D1N000003",
         "vote_id": "1489",
-        "dossier_id": "DLR5L16N47510"
+        "dossier_id": "DLR5L16N47510",
+        "seance_id": "RUANR5L16S2023IDS27039"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/282": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000282",
         "vote_id": "149",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26214"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1181/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1181P0D1N000005",
         "vote_id": "1490",
-        "dossier_id": "DLR5L16N47510"
+        "dossier_id": "DLR5L16N47510",
+        "seance_id": "RUANR5L16S2023IDS27039"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1181/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1181P0D1N000004",
         "vote_id": "1491",
-        "dossier_id": "DLR5L16N47510"
+        "dossier_id": "DLR5L16N47510",
+        "seance_id": "RUANR5L16S2023IDS27039"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/100": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000100",
         "vote_id": "1493",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/48": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000048",
         "vote_id": "1494",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/19": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000019",
         "vote_id": "1496",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/33": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000033",
         "vote_id": "1497",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/70": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000070",
         "vote_id": "1498",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/12": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000012",
         "vote_id": "1499",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/193": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000193",
         "vote_id": "150",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1011/AN/49": {
         "amendement_id": "AMANR5L16PO791932B1011P0D1N000049",
         "vote_id": "1500",
-        "dossier_id": "DLR5L16N47443"
+        "dossier_id": "DLR5L16N47443",
+        "seance_id": "RUANR5L16S2023IDS27040"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1179/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC1179P0D1N000020",
         "vote_id": "1502",
-        "dossier_id": "DLR5L16N46767"
+        "dossier_id": "DLR5L16N46767",
+        "seance_id": "RUANR5L16S2023IDS27041"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/394": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000394",
         "vote_id": "1505",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27057"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000061",
         "vote_id": "1506",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27057"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/401": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000401",
         "vote_id": "1507",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27057"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/153": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000153",
         "vote_id": "1508",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27057"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000063",
         "vote_id": "1509",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27057"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/1072": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N001072",
         "vote_id": "151",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000066",
         "vote_id": "1514",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/318": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000318",
         "vote_id": "152",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/374": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000374",
         "vote_id": "1521",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/252": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000252",
         "vote_id": "1522",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/275": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000275",
         "vote_id": "1523",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000096",
         "vote_id": "1525",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/92": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000092",
         "vote_id": "1526",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/169": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000169",
         "vote_id": "1527",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/166": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000166",
         "vote_id": "1528",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/230": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000230",
         "vote_id": "1529",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/194": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000194",
         "vote_id": "153",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/337": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000337",
         "vote_id": "1530",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000004",
         "vote_id": "1537",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000003",
         "vote_id": "1538",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000002",
         "vote_id": "1539",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/492": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000492",
         "vote_id": "154",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/303": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000303",
         "vote_id": "1540",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/537": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000537",
         "vote_id": "1541",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/113": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000113",
         "vote_id": "1543",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/492": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000492",
         "vote_id": "1544",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/155": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000155",
         "vote_id": "1545",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000074",
         "vote_id": "1546",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000124",
         "vote_id": "1547",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/125": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000125",
         "vote_id": "1548",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/415": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000415",
         "vote_id": "1550",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/416": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000416",
         "vote_id": "1551",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/418": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000418",
         "vote_id": "1552",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/417": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000417",
         "vote_id": "1553",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/411": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000411",
         "vote_id": "1554",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/144": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000144",
         "vote_id": "1555",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/419": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000419",
         "vote_id": "1556",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/77": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000077",
         "vote_id": "1557",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/493": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000493",
         "vote_id": "1558",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/599": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000599",
         "vote_id": "156",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000032",
         "vote_id": "1560",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/81": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000081",
         "vote_id": "1561",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/82": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000082",
         "vote_id": "1562",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/503": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000503",
         "vote_id": "1563",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/558": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000558",
         "vote_id": "1566",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/574": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000574",
         "vote_id": "1567",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/561": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000561",
         "vote_id": "1568",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/568": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000568",
         "vote_id": "1569",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/810": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000810",
         "vote_id": "157",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/560": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000560",
         "vote_id": "1570",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/90": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000090",
         "vote_id": "1571",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/187": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000187",
         "vote_id": "1573",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/139": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000139",
         "vote_id": "1574",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/513": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000513",
         "vote_id": "1576",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/402": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000402",
         "vote_id": "158",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/312": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000312",
         "vote_id": "1581",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27061"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/438": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000438",
         "vote_id": "1586",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27062"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1225/AN/440": {
         "amendement_id": "AMANR5L16PO791932BTC1225P0D1N000440",
         "vote_id": "1587",
-        "dossier_id": "DLR5L16N47006"
+        "dossier_id": "DLR5L16N47006",
+        "seance_id": "RUANR5L16S2023IDS27062"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/403": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000403",
         "vote_id": "159",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1330": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001330",
         "vote_id": "1591",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27069"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/304": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000304",
         "vote_id": "1592",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27069"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1331": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001331",
         "vote_id": "1593",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27070"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1771": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001771",
         "vote_id": "1594",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27070"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/563": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000563",
         "vote_id": "1595",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27070"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/203": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000203",
         "vote_id": "1596",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27070"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/517": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000517",
         "vote_id": "1597",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/576": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000576",
         "vote_id": "1598",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000065",
         "vote_id": "1599",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/76": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000076",
         "vote_id": "160",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1333": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001333",
         "vote_id": "1600",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1435": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001435",
         "vote_id": "1601",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/504": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000504",
         "vote_id": "1602",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1332": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001332",
         "vote_id": "1603",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/518": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000518",
         "vote_id": "1604",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27071"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/78": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000078",
         "vote_id": "161",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/790": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000790",
         "vote_id": "162",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26215"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1014": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001014",
         "vote_id": "1620",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1079": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001079",
         "vote_id": "1621",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1509": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001509",
         "vote_id": "1622",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1510": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001510",
         "vote_id": "1623",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1471": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001471",
         "vote_id": "1624",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/323": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000323",
         "vote_id": "1625",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27073"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/585": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000585",
         "vote_id": "1627",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/169": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000169",
         "vote_id": "1628",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1501": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001501",
         "vote_id": "1629",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/147": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000147",
         "vote_id": "163",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/252": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000252",
         "vote_id": "1630",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1195": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001195",
         "vote_id": "1631",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1106": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001106",
         "vote_id": "1632",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27074"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1605": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001605",
         "vote_id": "1633",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/541": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000541",
         "vote_id": "1634",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1637": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001637",
         "vote_id": "1635",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1735": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001735",
         "vote_id": "1636",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1431": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001431",
         "vote_id": "1637",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1675": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001675",
         "vote_id": "1638",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/224": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000224",
         "vote_id": "1639",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/79": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000079",
         "vote_id": "164",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/331": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000331",
         "vote_id": "1640",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/602": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000602",
         "vote_id": "1641",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/896": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000896",
         "vote_id": "1642",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/280": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000280",
         "vote_id": "1643",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1363": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001363",
         "vote_id": "1644",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1174": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001174",
         "vote_id": "1645",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27075"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/292": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000292",
         "vote_id": "1646",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27076"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/302": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000302",
         "vote_id": "1647",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27076"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/295": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000295",
         "vote_id": "1648",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27076"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1715": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001715",
         "vote_id": "1649",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27076"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/80": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000080",
         "vote_id": "165",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1712": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001712",
         "vote_id": "1650",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27076"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1516": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001516",
         "vote_id": "1651",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/298": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000298",
         "vote_id": "1652",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1610": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001610",
         "vote_id": "1653",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/768": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000768",
         "vote_id": "1654",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/352": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000352",
         "vote_id": "1655",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/629": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000629",
         "vote_id": "1656",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/909": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000909",
         "vote_id": "1657",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/911": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000911",
         "vote_id": "1658",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/913": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000913",
         "vote_id": "1659",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/553": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000553",
         "vote_id": "166",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1421": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001421",
         "vote_id": "1660",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1731": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001731",
         "vote_id": "1661",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27077"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1823": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001823",
         "vote_id": "1662",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/915": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000915",
         "vote_id": "1663",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1381": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001381",
         "vote_id": "1664",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1480": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001480",
         "vote_id": "1665",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/360": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000360",
         "vote_id": "1666",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1414": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001414",
         "vote_id": "1667",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1505": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001505",
         "vote_id": "1668",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/632": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000632",
         "vote_id": "1669",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/817": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000817",
         "vote_id": "167",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1575": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001575",
         "vote_id": "1670",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/917": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000917",
         "vote_id": "1671",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/919": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000919",
         "vote_id": "1672",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1169": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001169",
         "vote_id": "1673",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1769": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001769",
         "vote_id": "1674",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/291": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000291",
         "vote_id": "1675",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1548": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001548",
         "vote_id": "1676",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1100": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001100",
         "vote_id": "1677",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/297": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000297",
         "vote_id": "1678",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1757": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001757",
         "vote_id": "1679",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/819": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000819",
         "vote_id": "168",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1059": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001059",
         "vote_id": "1680",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1061": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001061",
         "vote_id": "1681",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1644": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001644",
         "vote_id": "1682",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1221": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001221",
         "vote_id": "1684",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/480": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000480",
         "vote_id": "1685",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/490": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000490",
         "vote_id": "1686",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1202": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001202",
         "vote_id": "1687",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1697": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001697",
         "vote_id": "1688",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1235": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001235",
         "vote_id": "1689",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/279": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000279",
         "vote_id": "169",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1707": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001707",
         "vote_id": "1690",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1450": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001450",
         "vote_id": "1691",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/998": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000998",
         "vote_id": "1694",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1443": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001443",
         "vote_id": "1695",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000095",
         "vote_id": "1697",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1288": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001288",
         "vote_id": "1698",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/672": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000672",
         "vote_id": "17",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/669": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000669",
         "vote_id": "170",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/112": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000112",
         "vote_id": "1700",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1294": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001294",
         "vote_id": "1701",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/255": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000255",
         "vote_id": "1702",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1207": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001207",
         "vote_id": "1703",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1645": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001645",
         "vote_id": "1707",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27081"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/632": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000632",
         "vote_id": "171",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1140": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001140",
         "vote_id": "1712",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27081"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1647": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001647",
         "vote_id": "1714",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27081"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1478": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001478",
         "vote_id": "1716",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/937": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000937",
         "vote_id": "1718",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1040": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001040",
         "vote_id": "1719",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/635": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000635",
         "vote_id": "172",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1496": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001496",
         "vote_id": "1725",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1686": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001686",
         "vote_id": "1727",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/299": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000299",
         "vote_id": "1728",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/192": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000192",
         "vote_id": "173",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1318": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001318",
         "vote_id": "1733",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27082"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/693": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000693",
         "vote_id": "174",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000030",
         "vote_id": "1747",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/633": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000633",
         "vote_id": "175",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000023",
         "vote_id": "1754",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/25": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000025",
         "vote_id": "1755",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000026",
         "vote_id": "1756",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000019",
         "vote_id": "1757",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000027",
         "vote_id": "1758",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000033",
         "vote_id": "1759",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/652": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000652",
         "vote_id": "176",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26216"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1287/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC1287P0D1N000028",
         "vote_id": "1760",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27083"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/176": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N000176",
         "vote_id": "1765",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27084"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1234/AN/1391": {
         "amendement_id": "AMANR5L16PO791932BTC1234P0D1N001391",
         "vote_id": "1769",
-        "dossier_id": "DLR5L16N47509"
+        "dossier_id": "DLR5L16N47509",
+        "seance_id": "RUANR5L16S2023IDS27085"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/41": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000041",
         "vote_id": "1781",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1297/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC1297P0D1N000042",
         "vote_id": "1782",
-        "dossier_id": "DLR5L16N47595"
+        "dossier_id": "DLR5L16N47595",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1297/AN/45": {
         "amendement_id": "AMANR5L16PO791932BTC1297P0D1N000045",
         "vote_id": "1783",
-        "dossier_id": "DLR5L16N47595"
+        "dossier_id": "DLR5L16N47595",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000046",
         "vote_id": "1784",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000031",
         "vote_id": "1785",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000006",
         "vote_id": "1786",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000065",
         "vote_id": "1787",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000016",
         "vote_id": "1789",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000015",
         "vote_id": "1790",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000002",
         "vote_id": "1792",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000030",
         "vote_id": "1793",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27178"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000044",
         "vote_id": "1794",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27179"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000042",
         "vote_id": "1795",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27179"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1292/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC1292P0D1N000035",
         "vote_id": "1796",
-        "dossier_id": "DLR5L16N47622"
+        "dossier_id": "DLR5L16N47622",
+        "seance_id": "RUANR5L16S2023IDS27179"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1294/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1294P0D1N000003",
         "vote_id": "1798",
-        "dossier_id": "DLR5L16N46374"
+        "dossier_id": "DLR5L16N46374",
+        "seance_id": "RUANR5L16S2023IDS27179"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1294/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1294P0D1N000005",
         "vote_id": "1799",
-        "dossier_id": "DLR5L16N46374"
+        "dossier_id": "DLR5L16N46374",
+        "seance_id": "RUANR5L16S2023IDS27179"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/677": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000677",
         "vote_id": "18",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/603": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000603",
         "vote_id": "1803",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27238"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/233": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000233",
         "vote_id": "1805",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/984": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000984",
         "vote_id": "1806",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/619": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000619",
         "vote_id": "1807",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/578": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000578",
         "vote_id": "1808",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1326/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1326P0D1N000001",
         "vote_id": "1812",
-        "dossier_id": "DLR5L16N46409"
+        "dossier_id": "DLR5L16N46409",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1083": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001083",
         "vote_id": "1813",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/167": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000167",
         "vote_id": "1814",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000075",
         "vote_id": "1815",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/968": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000968",
         "vote_id": "1816",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/967": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000967",
         "vote_id": "1817",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/794": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000794",
         "vote_id": "1818",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000071",
         "vote_id": "1819",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000072",
         "vote_id": "1820",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/970": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000970",
         "vote_id": "1821",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1161": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001161",
         "vote_id": "1822",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/973": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000973",
         "vote_id": "1823",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/971": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000971",
         "vote_id": "1824",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/972": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000972",
         "vote_id": "1825",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/797": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000797",
         "vote_id": "1826",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1330/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1330P0D1N000023",
         "vote_id": "1828",
-        "dossier_id": "DLR5L16N46695"
+        "dossier_id": "DLR5L16N46695",
+        "seance_id": "RUANR5L16S2023IDS27242"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1330/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1330P0D1N000038",
         "vote_id": "1830",
-        "dossier_id": "DLR5L16N46695"
+        "dossier_id": "DLR5L16N46695",
+        "seance_id": "RUANR5L16S2023IDS27242"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1330/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC1330P0D1N000074",
         "vote_id": "1836",
-        "dossier_id": "DLR5L16N46695"
+        "dossier_id": "DLR5L16N46695",
+        "seance_id": "RUANR5L16S2023IDS27243"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1330/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC1330P0D1N000075",
         "vote_id": "1837",
-        "dossier_id": "DLR5L16N46695"
+        "dossier_id": "DLR5L16N46695",
+        "seance_id": "RUANR5L16S2023IDS27243"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1330/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC1330P0D1N000068",
         "vote_id": "1838",
-        "dossier_id": "DLR5L16N46695"
+        "dossier_id": "DLR5L16N46695",
+        "seance_id": "RUANR5L16S2023IDS27243"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1019": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001019",
         "vote_id": "1846",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27244"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/806": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000806",
         "vote_id": "1847",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27244"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/156": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000156",
         "vote_id": "1849",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27244"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1184": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001184",
         "vote_id": "1851",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27244"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1147": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001147",
         "vote_id": "1852",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27244"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/1028": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N001028",
         "vote_id": "1854",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27245"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/848": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000848",
         "vote_id": "1855",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27245"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/318": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000318",
         "vote_id": "1856",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27245"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1336/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1336P0D1N000027",
         "vote_id": "1857",
-        "dossier_id": "DLR5L16N47721"
+        "dossier_id": "DLR5L16N47721",
+        "seance_id": "RUANR5L16S2023IDS27245"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000032",
         "vote_id": "1859",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/191": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000191",
         "vote_id": "1860",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000033",
         "vote_id": "1861",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/219": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000219",
         "vote_id": "1862",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/82": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000082",
         "vote_id": "1863",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/172": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000172",
         "vote_id": "1864",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/167": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000167",
         "vote_id": "1865",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/34": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000034",
         "vote_id": "1866",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/83": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000083",
         "vote_id": "1867",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000026",
         "vote_id": "1868",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000124",
         "vote_id": "1869",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/192": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000192",
         "vote_id": "1870",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000038",
         "vote_id": "1871",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/112": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000112",
         "vote_id": "1872",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/205": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000205",
         "vote_id": "1873",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/103": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000103",
         "vote_id": "1874",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/241": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000241",
         "vote_id": "1875",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/114": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000114",
         "vote_id": "1876",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000111",
         "vote_id": "1877",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/206": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000206",
         "vote_id": "1879",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/204": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000204",
         "vote_id": "1880",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/202": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000202",
         "vote_id": "1882",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000035",
         "vote_id": "1884",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/178": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000178",
         "vote_id": "1885",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/180": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000180",
         "vote_id": "1887",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000070",
         "vote_id": "1888",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/263": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000263",
         "vote_id": "1889",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/181": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000181",
         "vote_id": "1891",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1290/AN/182": {
         "amendement_id": "AMANR5L16PO791932BTC1290P0D1N000182",
         "vote_id": "1893",
-        "dossier_id": "DLR5L16N47637"
+        "dossier_id": "DLR5L16N47637",
+        "seance_id": "RUANR5L16S2023IDS27398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000018",
         "vote_id": "1895",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/119": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000119",
         "vote_id": "1897",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/121": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000121",
         "vote_id": "1898",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000057",
         "vote_id": "1899",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/684": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000684",
         "vote_id": "19",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000052",
         "vote_id": "1900",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000054",
         "vote_id": "1901",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000022",
         "vote_id": "1902",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/315": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000315",
         "vote_id": "1903",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27297"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000059",
         "vote_id": "1904",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000043",
         "vote_id": "1905",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/351": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000351",
         "vote_id": "1906",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000006",
         "vote_id": "1907",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/406": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000406",
         "vote_id": "1908",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/109": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000109",
         "vote_id": "1909",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/397": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000397",
         "vote_id": "1911",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/384": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000384",
         "vote_id": "1912",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/408": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000408",
         "vote_id": "1913",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000062",
         "vote_id": "1914",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27298"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1348/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1348P0D1N000003",
         "vote_id": "1915",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27299"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1348/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1348P0D1N000016",
         "vote_id": "1917",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27299"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1348/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC1348P0D1N000018",
         "vote_id": "1918",
-        "dossier_id": "DLR5L16N47975"
+        "dossier_id": "DLR5L16N47975",
+        "seance_id": "RUANR5L16S2023IDS27299"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/333": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000333",
         "vote_id": "1921",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27305"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000093",
         "vote_id": "1922",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27305"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/327": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000327",
         "vote_id": "1923",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27305"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/216": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000216",
         "vote_id": "1925",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27305"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/163": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000163",
         "vote_id": "1928",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/221": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000221",
         "vote_id": "1929",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/220": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000220",
         "vote_id": "1930",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/224": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000224",
         "vote_id": "1931",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/375": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000375",
         "vote_id": "1932",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/232": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000232",
         "vote_id": "1935",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/372": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000372",
         "vote_id": "1937",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/792": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000792",
         "vote_id": "1938",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/368": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000368",
         "vote_id": "1939",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27300"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/53": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000053",
         "vote_id": "194",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26379"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000094",
         "vote_id": "1940",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27301"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/91": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000091",
         "vote_id": "1942",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27301"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/226": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000226",
         "vote_id": "1945",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27301"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/291": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000291",
         "vote_id": "1946",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27301"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1352/AN/298": {
         "amendement_id": "AMANR5L16PO791932BTC1352P0D1N000298",
         "vote_id": "1947",
-        "dossier_id": "DLR5L16N47571"
+        "dossier_id": "DLR5L16N47571",
+        "seance_id": "RUANR5L16S2023IDS27301"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/168": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000168",
         "vote_id": "1949",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27302"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000038",
         "vote_id": "195",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26379"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/364": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000364",
         "vote_id": "1950",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27302"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/600": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000600",
         "vote_id": "1951",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/73": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000073",
         "vote_id": "1952",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/477": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000477",
         "vote_id": "1953",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/110": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000110",
         "vote_id": "1954",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000001",
         "vote_id": "1955",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/601": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000601",
         "vote_id": "1956",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/610": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000610",
         "vote_id": "1957",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/612": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000612",
         "vote_id": "1958",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/479": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000479",
         "vote_id": "1959",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/58": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000058",
         "vote_id": "196",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26379"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/288": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000288",
         "vote_id": "1960",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/245": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000245",
         "vote_id": "1961",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/646": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000646",
         "vote_id": "1962",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/113": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000113",
         "vote_id": "1963",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/365": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000365",
         "vote_id": "1964",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/721": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000721",
         "vote_id": "1965",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/688": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000688",
         "vote_id": "1966",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/492": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000492",
         "vote_id": "1967",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/483": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000483",
         "vote_id": "1968",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/484": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000484",
         "vote_id": "1969",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000042",
         "vote_id": "197",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26379"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/660": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000660",
         "vote_id": "1970",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/823": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000823",
         "vote_id": "1971",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/725": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000725",
         "vote_id": "1972",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/493": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000493",
         "vote_id": "1973",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/490": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000490",
         "vote_id": "1974",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/285": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000285",
         "vote_id": "1975",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/366": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000366",
         "vote_id": "1976",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/367": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000367",
         "vote_id": "1977",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/664": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000664",
         "vote_id": "1978",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/665": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000665",
         "vote_id": "1979",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27303"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000061",
         "vote_id": "198",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26379"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/724": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000724",
         "vote_id": "1985",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/734": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000734",
         "vote_id": "1986",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/717": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000717",
         "vote_id": "1987",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/742": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000742",
         "vote_id": "1989",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/25": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000025",
         "vote_id": "199",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/480": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000480",
         "vote_id": "1990",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/634": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000634",
         "vote_id": "1991",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/737": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000737",
         "vote_id": "1995",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/399": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000399",
         "vote_id": "1996",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1359/AN/744": {
         "amendement_id": "AMANR5L16PO791932BTC1359P0D1N000744",
         "vote_id": "1998",
-        "dossier_id": "DLR5L16N46880"
+        "dossier_id": "DLR5L16N46880",
+        "seance_id": "RUANR5L16S2023IDS27455"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/906": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000906",
         "vote_id": "20",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/372": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000372",
         "vote_id": "2002",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/113": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000113",
         "vote_id": "2004",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/231": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000231",
         "vote_id": "2005",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/274": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000274",
         "vote_id": "2006",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/232": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000232",
         "vote_id": "2007",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/235": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000235",
         "vote_id": "2008",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/234": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000234",
         "vote_id": "2009",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/320": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000320",
         "vote_id": "201",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/233": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000233",
         "vote_id": "2010",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000028",
         "vote_id": "2011",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/115": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000115",
         "vote_id": "2012",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000027",
         "vote_id": "2013",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/141": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000141",
         "vote_id": "2014",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/204": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000204",
         "vote_id": "2015",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/203": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000203",
         "vote_id": "2016",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/202": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000202",
         "vote_id": "2017",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/148": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000148",
         "vote_id": "2018",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/210": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000210",
         "vote_id": "2019",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/238": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000238",
         "vote_id": "202",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/109": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000109",
         "vote_id": "2020",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000014",
         "vote_id": "2021",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/112": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000112",
         "vote_id": "2022",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000006",
         "vote_id": "2023",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/289": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000289",
         "vote_id": "2024",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/288": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000288",
         "vote_id": "2025",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/287": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000287",
         "vote_id": "2026",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/290": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000290",
         "vote_id": "2027",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/291": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000291",
         "vote_id": "2028",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/292": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000292",
         "vote_id": "2029",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/217": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000217",
         "vote_id": "203",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/275": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000275",
         "vote_id": "2030",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/157": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000157",
         "vote_id": "2031",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/320": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000320",
         "vote_id": "2032",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/298": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000298",
         "vote_id": "2033",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000032",
         "vote_id": "2035",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/376": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000376",
         "vote_id": "2036",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000057",
         "vote_id": "2037",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/149": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000149",
         "vote_id": "2038",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/76": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000076",
         "vote_id": "2039",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000024",
         "vote_id": "204",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/89": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000089",
         "vote_id": "2040",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000033",
         "vote_id": "2041",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000061",
         "vote_id": "2042",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/60": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000060",
         "vote_id": "2044",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/303": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000303",
         "vote_id": "2045",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27358"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/150": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000150",
         "vote_id": "2047",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000007",
         "vote_id": "2049",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000065",
         "vote_id": "205",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000043",
         "vote_id": "2050",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/88": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000088",
         "vote_id": "2051",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/399": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000399",
         "vote_id": "2053",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/153": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000153",
         "vote_id": "2055",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27359"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/239": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000239",
         "vote_id": "2056",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/300": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000300",
         "vote_id": "2057",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000015",
         "vote_id": "2058",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000124",
         "vote_id": "2059",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/278": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000278",
         "vote_id": "206",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/156": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000156",
         "vote_id": "2060",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/219": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000219",
         "vote_id": "2061",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/243": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000243",
         "vote_id": "2062",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/73": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000073",
         "vote_id": "2063",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000031",
         "vote_id": "2064",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/125": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000125",
         "vote_id": "2065",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/377": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000377",
         "vote_id": "2066",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000016",
         "vote_id": "2067",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000056",
         "vote_id": "2068",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/159": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000159",
         "vote_id": "2069",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/232": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000232",
         "vote_id": "207",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26380"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/180": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000180",
         "vote_id": "2071",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/163": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000163",
         "vote_id": "2072",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/255": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000255",
         "vote_id": "2074",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27360"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/151": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000151",
         "vote_id": "2078",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/375": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000375",
         "vote_id": "2079",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/258": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000258",
         "vote_id": "2080",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/257": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000257",
         "vote_id": "2081",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/199": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000199",
         "vote_id": "2082",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000066",
         "vote_id": "2083",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/259": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000259",
         "vote_id": "2085",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000068",
         "vote_id": "2086",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/170": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000170",
         "vote_id": "2087",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/388": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000388",
         "vote_id": "209",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000052",
         "vote_id": "2091",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/58": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000058",
         "vote_id": "2092",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/185": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000185",
         "vote_id": "2093",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000054",
         "vote_id": "2094",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/53": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000053",
         "vote_id": "2095",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/339": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000339",
         "vote_id": "2096",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/381": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000381",
         "vote_id": "2098",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/207": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000207",
         "vote_id": "2099",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000096",
         "vote_id": "21",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/192": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000192",
         "vote_id": "210",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/318": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000318",
         "vote_id": "2101",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000063",
         "vote_id": "2104",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000065",
         "vote_id": "2107",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000059",
         "vote_id": "2108",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000070",
         "vote_id": "2109",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000040",
         "vote_id": "211",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000071",
         "vote_id": "2110",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1404/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC1404P0D1N000072",
         "vote_id": "2111",
-        "dossier_id": "DLR5L16N47979"
+        "dossier_id": "DLR5L16N47979",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1435/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1435P0D1N000005",
         "vote_id": "2113",
-        "dossier_id": "DLR5L16N47616"
+        "dossier_id": "DLR5L16N47616",
+        "seance_id": "RUANR5L16S2023IDS27363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1435/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1435P0D1N000014",
         "vote_id": "2114",
-        "dossier_id": "DLR5L16N47616"
+        "dossier_id": "DLR5L16N47616",
+        "seance_id": "RUANR5L16S2023IDS27364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1435/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1435P0D1N000006",
         "vote_id": "2115",
-        "dossier_id": "DLR5L16N47616"
+        "dossier_id": "DLR5L16N47616",
+        "seance_id": "RUANR5L16S2023IDS27364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1435/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC1435P0D1N000013",
         "vote_id": "2116",
-        "dossier_id": "DLR5L16N47616"
+        "dossier_id": "DLR5L16N47616",
+        "seance_id": "RUANR5L16S2023IDS27364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1435/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1435P0D1N000015",
         "vote_id": "2117",
-        "dossier_id": "DLR5L16N47616"
+        "dossier_id": "DLR5L16N47616",
+        "seance_id": "RUANR5L16S2023IDS27364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/227": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000227",
         "vote_id": "212",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1332": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001332",
         "vote_id": "2122",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/340": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000340",
         "vote_id": "2123",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/588": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000588",
         "vote_id": "2124",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/490": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000490",
         "vote_id": "2125",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/25": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000025",
         "vote_id": "2126",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/416": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000416",
         "vote_id": "2127",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27438"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1060": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001060",
         "vote_id": "2128",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27439"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/230": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000230",
         "vote_id": "2129",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27439"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/242": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000242",
         "vote_id": "213",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/322": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000322",
         "vote_id": "2130",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27440"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1445": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001445",
         "vote_id": "2131",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27440"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/915": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000915",
         "vote_id": "2132",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27440"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/600": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000600",
         "vote_id": "2133",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27440"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/880": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000880",
         "vote_id": "2134",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27440"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/846": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000846",
         "vote_id": "2138",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27441"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1330": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001330",
         "vote_id": "2139",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27441"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/304": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000304",
         "vote_id": "214",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000020",
         "vote_id": "2140",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27441"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/307": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000307",
         "vote_id": "2142",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/895": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000895",
         "vote_id": "2143",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/972": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000972",
         "vote_id": "2144",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/987": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000987",
         "vote_id": "2145",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/962": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000962",
         "vote_id": "2146",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/843": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000843",
         "vote_id": "2147",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1334": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001334",
         "vote_id": "2148",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/916": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000916",
         "vote_id": "2149",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000070",
         "vote_id": "215",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000016",
         "vote_id": "2150",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/325": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000325",
         "vote_id": "2151",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27442"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/338": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000338",
         "vote_id": "2152",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/126": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000126",
         "vote_id": "2153",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/133": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000133",
         "vote_id": "2154",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/845": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000845",
         "vote_id": "2155",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/914": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000914",
         "vote_id": "2156",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/694": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000694",
         "vote_id": "2157",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1381": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001381",
         "vote_id": "2158",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/918": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000918",
         "vote_id": "2159",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/41": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000041",
         "vote_id": "216",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1477": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001477",
         "vote_id": "2160",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1478": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001478",
         "vote_id": "2161",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1479": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001479",
         "vote_id": "2162",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1480": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001480",
         "vote_id": "2163",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/594": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000594",
         "vote_id": "2164",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/336": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000336",
         "vote_id": "2165",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1429": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001429",
         "vote_id": "2166",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1305": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001305",
         "vote_id": "2167",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/809": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000809",
         "vote_id": "2168",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/811": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000811",
         "vote_id": "2169",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27443"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/909": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000909",
         "vote_id": "2170",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/989": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000989",
         "vote_id": "2171",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/911": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000911",
         "vote_id": "2172",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1121": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001121",
         "vote_id": "2173",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1339": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001339",
         "vote_id": "2174",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/580": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000580",
         "vote_id": "2175",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/648": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000648",
         "vote_id": "2176",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/729": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000729",
         "vote_id": "2177",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/275": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000275",
         "vote_id": "2179",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/168": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000168",
         "vote_id": "218",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1449": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001449",
         "vote_id": "2180",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/517": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000517",
         "vote_id": "2182",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/624": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000624",
         "vote_id": "2183",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/357": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000357",
         "vote_id": "2184",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/267": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000267",
         "vote_id": "219",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/308": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000308",
         "vote_id": "2192",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1070": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001070",
         "vote_id": "2195",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1050": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001050",
         "vote_id": "2196",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1417": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001417",
         "vote_id": "2197",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1062": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001062",
         "vote_id": "2198",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1163": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001163",
         "vote_id": "2199",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/100": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000100",
         "vote_id": "22",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/219": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000219",
         "vote_id": "220",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1164": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001164",
         "vote_id": "2200",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1064": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001064",
         "vote_id": "2201",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1165": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001165",
         "vote_id": "2202",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1352": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001352",
         "vote_id": "2203",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/602": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000602",
         "vote_id": "2204",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1089": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001089",
         "vote_id": "2205",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1067": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001067",
         "vote_id": "2206",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1066": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001066",
         "vote_id": "2207",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1353": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001353",
         "vote_id": "2208",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/604": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000604",
         "vote_id": "2209",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/374": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000374",
         "vote_id": "221",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1418": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001418",
         "vote_id": "2211",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/221": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000221",
         "vote_id": "2214",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1139": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001139",
         "vote_id": "2215",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27446"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/700": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000700",
         "vote_id": "2217",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1512": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001512",
         "vote_id": "2219",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0276/AN/207": {
         "amendement_id": "AMANR5L16PO791932BTC0276P0D1N000207",
         "vote_id": "222",
-        "dossier_id": "DLR5L16N46266"
+        "dossier_id": "DLR5L16N46266",
+        "seance_id": "RUANR5L16S2023IDS26382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1444": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001444",
         "vote_id": "2221",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/853": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000853",
         "vote_id": "2222",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/137": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000137",
         "vote_id": "2223",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/656": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000656",
         "vote_id": "2224",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1410": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001410",
         "vote_id": "2225",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/680": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000680",
         "vote_id": "2226",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27447"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1177": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001177",
         "vote_id": "2228",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1273": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001273",
         "vote_id": "2230",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1088": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001088",
         "vote_id": "2231",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/617": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000617",
         "vote_id": "2232",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/376": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000376",
         "vote_id": "2235",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/716": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000716",
         "vote_id": "2236",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/781": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000781",
         "vote_id": "2237",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/721": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000721",
         "vote_id": "2238",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/273": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000273",
         "vote_id": "2239",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0280/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC0280P0D1N000023",
         "vote_id": "224",
-        "dossier_id": "DLR5L16N46116"
+        "dossier_id": "DLR5L16N46116",
+        "seance_id": "RUANR5L16S2023IDS26383"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/158": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000158",
         "vote_id": "2240",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/891": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000891",
         "vote_id": "2241",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/815": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000815",
         "vote_id": "2242",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27448"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/414": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000414",
         "vote_id": "2243",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/759": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000759",
         "vote_id": "2244",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/159": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000159",
         "vote_id": "2245",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/726": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000726",
         "vote_id": "2246",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000014",
         "vote_id": "2247",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000008",
         "vote_id": "2248",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1232": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001232",
         "vote_id": "2249",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/313": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000313",
         "vote_id": "2250",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1415": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001415",
         "vote_id": "2251",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/438": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000438",
         "vote_id": "2252",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1142": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001142",
         "vote_id": "2253",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/783": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000783",
         "vote_id": "2254",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27449"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000015",
         "vote_id": "2258",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/626": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000626",
         "vote_id": "2259",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1179": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001179",
         "vote_id": "2260",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1419": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001419",
         "vote_id": "2261",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/780": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000780",
         "vote_id": "2262",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/369": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000369",
         "vote_id": "2263",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1155": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001155",
         "vote_id": "2264",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1156": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001156",
         "vote_id": "2265",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1157": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001157",
         "vote_id": "2266",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000043",
         "vote_id": "2267",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/403": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000403",
         "vote_id": "2268",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/873": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000873",
         "vote_id": "2269",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/315": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000315",
         "vote_id": "2270",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/472": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000472",
         "vote_id": "2271",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000042",
         "vote_id": "2272",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27450"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/747": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000747",
         "vote_id": "2273",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1277": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001277",
         "vote_id": "2274",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1530": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001530",
         "vote_id": "2275",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/593": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000593",
         "vote_id": "2276",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/266": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000266",
         "vote_id": "2277",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/462": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000462",
         "vote_id": "2278",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000044",
         "vote_id": "2279",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000046",
         "vote_id": "2280",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1391": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001391",
         "vote_id": "2281",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27451"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1276": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001276",
         "vote_id": "2283",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1031": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001031",
         "vote_id": "2284",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1034": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001034",
         "vote_id": "2285",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/872": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000872",
         "vote_id": "2286",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000047",
         "vote_id": "2287",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000048",
         "vote_id": "2288",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000049",
         "vote_id": "2289",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1160": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001160",
         "vote_id": "2290",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1158": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001158",
         "vote_id": "2291",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1159": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001159",
         "vote_id": "2292",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1161": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001161",
         "vote_id": "2293",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/667": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000667",
         "vote_id": "2294",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/50": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000050",
         "vote_id": "2295",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1154": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001154",
         "vote_id": "2296",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1373": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001373",
         "vote_id": "2297",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000013",
         "vote_id": "2298",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/854": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000854",
         "vote_id": "2299",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/743": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000743",
         "vote_id": "23",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1103": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001103",
         "vote_id": "2300",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000070",
         "vote_id": "2301",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000052",
         "vote_id": "2302",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000072",
         "vote_id": "2303",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000074",
         "vote_id": "2304",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1361": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001361",
         "vote_id": "2305",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/808": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000808",
         "vote_id": "2306",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1362": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001362",
         "vote_id": "2307",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1363": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001363",
         "vote_id": "2308",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1364": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001364",
         "vote_id": "2309",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27452"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/481": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000481",
         "vote_id": "2310",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/482": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000482",
         "vote_id": "2311",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000075",
         "vote_id": "2312",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/778": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000778",
         "vote_id": "2313",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/474": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000474",
         "vote_id": "2314",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/467": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000467",
         "vote_id": "2315",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/375": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000375",
         "vote_id": "2316",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1056": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001056",
         "vote_id": "2317",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1130": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001130",
         "vote_id": "2318",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/855": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000855",
         "vote_id": "2319",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/691": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N000691",
         "vote_id": "2320",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1178": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001178",
         "vote_id": "2321",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1229": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001229",
         "vote_id": "2322",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1230": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001230",
         "vote_id": "2323",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1440/AN/1096": {
         "amendement_id": "AMANR5L16PO791932BTC1440P0D1N001096",
         "vote_id": "2324",
-        "dossier_id": "DLR5L16N47779"
+        "dossier_id": "DLR5L16N47779",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1441/AN/205": {
         "amendement_id": "AMANR5L16PO791932BTC1441P0D1N000205",
         "vote_id": "2327",
-        "dossier_id": "DLR5L16N47780"
+        "dossier_id": "DLR5L16N47780",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1441/AN/134": {
         "amendement_id": "AMANR5L16PO791932BTC1441P0D1N000134",
         "vote_id": "2334",
-        "dossier_id": "DLR5L16N47780"
+        "dossier_id": "DLR5L16N47780",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1441/AN/116": {
         "amendement_id": "AMANR5L16PO791932BTC1441P0D1N000116",
         "vote_id": "2336",
-        "dossier_id": "DLR5L16N47780"
+        "dossier_id": "DLR5L16N47780",
+        "seance_id": "RUANR5L16S2023IDS27453"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/996": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000996",
         "vote_id": "2344",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1401": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001401",
         "vote_id": "2345",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/514": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000514",
         "vote_id": "2346",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1306": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001306",
         "vote_id": "2347",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1307": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001307",
         "vote_id": "2348",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1002": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001002",
         "vote_id": "2349",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27497"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/427": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000427",
         "vote_id": "2351",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27500"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/636": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000636",
         "vote_id": "2352",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27500"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1005": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001005",
         "vote_id": "2353",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27500"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/515": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000515",
         "vote_id": "2354",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27500"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1025": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001025",
         "vote_id": "2358",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1024": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001024",
         "vote_id": "2359",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/690": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000690",
         "vote_id": "2360",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/366": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000366",
         "vote_id": "2361",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/841": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000841",
         "vote_id": "2362",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1667": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001667",
         "vote_id": "2363",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1666": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001666",
         "vote_id": "2364",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1693": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001693",
         "vote_id": "2365",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1692": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001692",
         "vote_id": "2366",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1680": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001680",
         "vote_id": "2367",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1687": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001687",
         "vote_id": "2368",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1686": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001686",
         "vote_id": "2369",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/111": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000111",
         "vote_id": "237",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1669": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001669",
         "vote_id": "2370",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1670": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001670",
         "vote_id": "2371",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1684": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001684",
         "vote_id": "2372",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1689": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001689",
         "vote_id": "2373",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1688": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001688",
         "vote_id": "2374",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1674": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001674",
         "vote_id": "2375",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1682": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001682",
         "vote_id": "2376",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1704": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001704",
         "vote_id": "2377",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1671": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001671",
         "vote_id": "2378",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1676": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001676",
         "vote_id": "2379",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1705": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001705",
         "vote_id": "2380",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1691": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001691",
         "vote_id": "2381",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1677": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001677",
         "vote_id": "2382",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1678": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001678",
         "vote_id": "2383",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1695": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001695",
         "vote_id": "2384",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1665": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001665",
         "vote_id": "2385",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/463": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000463",
         "vote_id": "2386",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/890": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000890",
         "vote_id": "2392",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/676": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000676",
         "vote_id": "2393",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/699": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000699",
         "vote_id": "2394",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/520": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000520",
         "vote_id": "2395",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/917": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000917",
         "vote_id": "2397",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1065": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001065",
         "vote_id": "2398",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/97": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000097",
         "vote_id": "24",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/71": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000071",
         "vote_id": "241",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000049",
         "vote_id": "2414",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/81": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000081",
         "vote_id": "2415",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000020",
         "vote_id": "2416",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000008",
         "vote_id": "2417",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000055",
         "vote_id": "2418",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000023",
         "vote_id": "2419",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/103": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000103",
         "vote_id": "2421",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000028",
         "vote_id": "2422",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000093",
         "vote_id": "2423",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000043",
         "vote_id": "2424",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000010",
         "vote_id": "2425",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000044",
         "vote_id": "2426",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000002",
         "vote_id": "2427",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000061",
         "vote_id": "2428",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/8": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000008",
         "vote_id": "243",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000063",
         "vote_id": "2431",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000094",
         "vote_id": "2432",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000068",
         "vote_id": "2433",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000001",
         "vote_id": "2434",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000046",
         "vote_id": "2435",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000038",
         "vote_id": "2436",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000030",
         "vote_id": "2437",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/101": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000101",
         "vote_id": "2438",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000124",
         "vote_id": "2439",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000016",
         "vote_id": "2441",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/85": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000085",
         "vote_id": "2442",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1537/AN/125": {
         "amendement_id": "AMANR5L16PO791932BTC1537P0D1N000125",
         "vote_id": "2443",
-        "dossier_id": "DLR5L16N48392"
+        "dossier_id": "DLR5L16N48392",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1722": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001722",
         "vote_id": "2445",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000056",
         "vote_id": "2446",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000057",
         "vote_id": "2447",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/617": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000617",
         "vote_id": "2448",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/177": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000177",
         "vote_id": "2449",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/56": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000056",
         "vote_id": "245",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/663": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000663",
         "vote_id": "2450",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/920": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000920",
         "vote_id": "2454",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/776": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000776",
         "vote_id": "2455",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/915": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000915",
         "vote_id": "2456",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/916": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000916",
         "vote_id": "2457",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/914": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000914",
         "vote_id": "2458",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/349": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000349",
         "vote_id": "2459",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1521": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001521",
         "vote_id": "2460",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/505": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000505",
         "vote_id": "2461",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/820": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000820",
         "vote_id": "2462",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/533": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000533",
         "vote_id": "2465",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/603": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000603",
         "vote_id": "2466",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/833": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000833",
         "vote_id": "2467",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/523": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000523",
         "vote_id": "2468",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1110": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001110",
         "vote_id": "2469",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/819": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000819",
         "vote_id": "2471",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/333": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000333",
         "vote_id": "2472",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1460": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001460",
         "vote_id": "2473",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/706": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000706",
         "vote_id": "2474",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/848": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000848",
         "vote_id": "2475",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1119": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001119",
         "vote_id": "2476",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1461": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001461",
         "vote_id": "2478",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/703": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000703",
         "vote_id": "2479",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/72": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000072",
         "vote_id": "248",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1127": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001127",
         "vote_id": "2480",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/159": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000159",
         "vote_id": "2481",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/609": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000609",
         "vote_id": "2482",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1126": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001126",
         "vote_id": "2483",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27538"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/755": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000755",
         "vote_id": "2485",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1600": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001600",
         "vote_id": "2486",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000026",
         "vote_id": "2487",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1131": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001131",
         "vote_id": "2488",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/707": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000707",
         "vote_id": "2490",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1740": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001740",
         "vote_id": "2492",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1114": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001114",
         "vote_id": "2493",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000024",
         "vote_id": "2494",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1135": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001135",
         "vote_id": "2495",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/102": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000102",
         "vote_id": "25",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0272/AN/10": {
         "amendement_id": "AMANR5L16PO791932B0272P0D1N000010",
         "vote_id": "250",
-        "dossier_id": "DLR5L16N46346"
+        "dossier_id": "DLR5L16N46346",
+        "seance_id": "RUANR5L16S2023IDS26389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1176": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001176",
         "vote_id": "2500",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1144": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001144",
         "vote_id": "2501",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/92": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000092",
         "vote_id": "2502",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1299": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001299",
         "vote_id": "2503",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/931": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000931",
         "vote_id": "2504",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1142": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001142",
         "vote_id": "2505",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1146": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001146",
         "vote_id": "2506",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1168": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001168",
         "vote_id": "2507",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1167": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001167",
         "vote_id": "2508",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1435": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001435",
         "vote_id": "2509",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/153": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000153",
         "vote_id": "2510",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000007",
         "vote_id": "2511",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27539"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/29": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000029",
         "vote_id": "2515",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27540"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/1382": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N001382",
         "vote_id": "2517",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27540"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1512/AN/196": {
         "amendement_id": "AMANR5L16PO791932BTC1512P0D1N000196",
         "vote_id": "2518",
-        "dossier_id": "DLR5L16N47917"
+        "dossier_id": "DLR5L16N47917",
+        "seance_id": "RUANR5L16S2023IDS27540"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/392": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000392",
         "vote_id": "2522",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000070",
         "vote_id": "2523",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/991": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000991",
         "vote_id": "2524",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000016",
         "vote_id": "2525",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/319": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000319",
         "vote_id": "2526",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000021",
         "vote_id": "2527",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1206": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001206",
         "vote_id": "2528",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/152": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000152",
         "vote_id": "2529",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/766": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000766",
         "vote_id": "253",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1296": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001296",
         "vote_id": "2530",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/342": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000342",
         "vote_id": "2531",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27599"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/158": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000158",
         "vote_id": "2532",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27599"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1222": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001222",
         "vote_id": "2533",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27599"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000057",
         "vote_id": "2534",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27599"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000030",
         "vote_id": "2535",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27599"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/302": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000302",
         "vote_id": "2536",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1207": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001207",
         "vote_id": "2537",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/871": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000871",
         "vote_id": "2538",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/890": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000890",
         "vote_id": "2539",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/338": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000338",
         "vote_id": "2540",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/351": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000351",
         "vote_id": "2541",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1244": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001244",
         "vote_id": "2542",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1319": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001319",
         "vote_id": "2543",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/896": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000896",
         "vote_id": "2544",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1164": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001164",
         "vote_id": "2546",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/870": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000870",
         "vote_id": "2548",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/492": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000492",
         "vote_id": "2549",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3121": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003121",
         "vote_id": "255",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/538": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000538",
         "vote_id": "2550",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/541": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000541",
         "vote_id": "2551",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/173": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000173",
         "vote_id": "2552",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1845": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001845",
         "vote_id": "2554",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1843": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001843",
         "vote_id": "2555",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1853": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001853",
         "vote_id": "2556",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/183": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000183",
         "vote_id": "2557",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/180": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000180",
         "vote_id": "2558",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/524": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000524",
         "vote_id": "2559",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1481": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001481",
         "vote_id": "256",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/200": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000200",
         "vote_id": "2560",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1380": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001380",
         "vote_id": "2561",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27603"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1410": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001410",
         "vote_id": "2562",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1830": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001830",
         "vote_id": "2563",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/300": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000300",
         "vote_id": "2564",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/778": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000778",
         "vote_id": "2565",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1415": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001415",
         "vote_id": "2566",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1417": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001417",
         "vote_id": "2567",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1425": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001425",
         "vote_id": "2568",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/474": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000474",
         "vote_id": "257",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1846": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001846",
         "vote_id": "2570",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/739": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000739",
         "vote_id": "2572",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1481": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001481",
         "vote_id": "2573",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1505": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001505",
         "vote_id": "2574",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/69": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000069",
         "vote_id": "2575",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/753": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000753",
         "vote_id": "2576",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000071",
         "vote_id": "2577",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1212": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001212",
         "vote_id": "2578",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1530": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001530",
         "vote_id": "2579",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/39": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000039",
         "vote_id": "258",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/760": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000760",
         "vote_id": "2580",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1559": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001559",
         "vote_id": "2581",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000072",
         "vote_id": "2582",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/708": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000708",
         "vote_id": "2583",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/248": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000248",
         "vote_id": "2584",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1550": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001550",
         "vote_id": "2585",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1552": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001552",
         "vote_id": "2586",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/413": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000413",
         "vote_id": "2587",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/415": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000415",
         "vote_id": "2588",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/91": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000091",
         "vote_id": "2589",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/539": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000539",
         "vote_id": "259",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/416": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000416",
         "vote_id": "2590",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/729": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000729",
         "vote_id": "2593",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1183": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001183",
         "vote_id": "2594",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/223": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000223",
         "vote_id": "2595",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/167": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000167",
         "vote_id": "2596",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1553": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001553",
         "vote_id": "2597",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27606"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/257": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000257",
         "vote_id": "2598",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/277": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000277",
         "vote_id": "2599",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/611": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000611",
         "vote_id": "26",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000003",
         "vote_id": "260",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1154": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001154",
         "vote_id": "2600",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1609": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001609",
         "vote_id": "2601",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1612": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001612",
         "vote_id": "2602",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1859": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001859",
         "vote_id": "2604",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1755": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001755",
         "vote_id": "2605",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/735": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000735",
         "vote_id": "2606",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2023IDS27607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1221": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001221",
         "vote_id": "261",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/625": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000625",
         "vote_id": "2619",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27611"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1752": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001752",
         "vote_id": "2620",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27611"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1747": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001747",
         "vote_id": "2621",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27611"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1748": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001748",
         "vote_id": "2622",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27611"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/795": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000795",
         "vote_id": "2626",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27612"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/417": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000417",
         "vote_id": "2628",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27612"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/393": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000393",
         "vote_id": "263",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000043",
         "vote_id": "2630",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27612"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1167": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001167",
         "vote_id": "2631",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000013",
         "vote_id": "2632",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/145": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000145",
         "vote_id": "2633",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/362": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000362",
         "vote_id": "2634",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/364": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000364",
         "vote_id": "2635",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/839": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000839",
         "vote_id": "2636",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/363": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000363",
         "vote_id": "2637",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/366": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000366",
         "vote_id": "2638",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/164": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000164",
         "vote_id": "2639",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1777": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001777",
         "vote_id": "264",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26390"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000007",
         "vote_id": "2640",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/131": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N000131",
         "vote_id": "2641",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1469": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001469",
         "vote_id": "2642",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1673/AN/1396": {
         "amendement_id": "AMANR5L16PO791932BTC1673P0D1N001396",
         "vote_id": "2643",
-        "dossier_id": "DLR5L16N48163"
+        "dossier_id": "DLR5L16N48163",
+        "seance_id": "RUANR5L16S2024IDS27613"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/364": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000364",
         "vote_id": "2646",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/376": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000376",
         "vote_id": "2647",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000001",
         "vote_id": "2648",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1039": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001039",
         "vote_id": "2649",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2472": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002472",
         "vote_id": "265",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/377": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000377",
         "vote_id": "2650",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000026",
         "vote_id": "2651",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/275": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000275",
         "vote_id": "2652",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27614"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/276": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000276",
         "vote_id": "2653",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/277": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000277",
         "vote_id": "2654",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/278": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000278",
         "vote_id": "2655",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/381": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000381",
         "vote_id": "2656",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/375": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000375",
         "vote_id": "2657",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000074",
         "vote_id": "2658",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/374": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000374",
         "vote_id": "2659",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3367": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003367",
         "vote_id": "266",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/444": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000444",
         "vote_id": "2660",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/838": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000838",
         "vote_id": "2661",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/384": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000384",
         "vote_id": "2662",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1099": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001099",
         "vote_id": "2663",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/387": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000387",
         "vote_id": "2664",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/51": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000051",
         "vote_id": "2666",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000003",
         "vote_id": "2667",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/421": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000421",
         "vote_id": "2668",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27615"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000006",
         "vote_id": "2669",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2470": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002470",
         "vote_id": "267",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/537": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000537",
         "vote_id": "2670",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/286": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000286",
         "vote_id": "2671",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1102": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001102",
         "vote_id": "2672",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000009",
         "vote_id": "2673",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/744": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000744",
         "vote_id": "2675",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/746": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000746",
         "vote_id": "2676",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000055",
         "vote_id": "2677",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000056",
         "vote_id": "2678",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3123": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003123",
         "vote_id": "268",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1043": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001043",
         "vote_id": "2680",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/416": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000416",
         "vote_id": "2681",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/539": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000539",
         "vote_id": "2682",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/901": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000901",
         "vote_id": "2683",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/941": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000941",
         "vote_id": "2684",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/80": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000080",
         "vote_id": "2686",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/438": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000438",
         "vote_id": "2687",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27616"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/914": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000914",
         "vote_id": "2689",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3486": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003486",
         "vote_id": "269",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/478": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000478",
         "vote_id": "2690",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/581": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000581",
         "vote_id": "2691",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/433": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000433",
         "vote_id": "2692",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000019",
         "vote_id": "2697",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000023",
         "vote_id": "2698",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000071",
         "vote_id": "2699",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/895": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000895",
         "vote_id": "27",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3126": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003126",
         "vote_id": "270",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/103": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000103",
         "vote_id": "2700",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000075",
         "vote_id": "2701",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000003",
         "vote_id": "2702",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/73": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000073",
         "vote_id": "2703",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000031",
         "vote_id": "2704",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000065",
         "vote_id": "2705",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/101": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000101",
         "vote_id": "2706",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000022",
         "vote_id": "2707",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/79": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000079",
         "vote_id": "2708",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1690/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1690P0D1N000026",
         "vote_id": "2709",
-        "dossier_id": "DLR5L16N48681"
+        "dossier_id": "DLR5L16N48681",
+        "seance_id": "RUANR5L16S2024IDS27618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2238": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002238",
         "vote_id": "271",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26391"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/292": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000292",
         "vote_id": "2713",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/288": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000288",
         "vote_id": "2714",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/490": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000490",
         "vote_id": "2715",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/497": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000497",
         "vote_id": "2716",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/761": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000761",
         "vote_id": "272",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/654": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000654",
         "vote_id": "2723",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27621"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/768": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000768",
         "vote_id": "2724",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27621"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/936": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000936",
         "vote_id": "2725",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27621"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/930": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000930",
         "vote_id": "2726",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/737": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000737",
         "vote_id": "2727",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1044": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001044",
         "vote_id": "2729",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1735": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001735",
         "vote_id": "273",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1126": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001126",
         "vote_id": "2731",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/770": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000770",
         "vote_id": "2733",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/564": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000564",
         "vote_id": "2734",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27622"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/110": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000110",
         "vote_id": "2736",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1121": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001121",
         "vote_id": "2737",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/591": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000591",
         "vote_id": "2738",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3127": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003127",
         "vote_id": "274",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1141": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001141",
         "vote_id": "2744",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1144": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001144",
         "vote_id": "2745",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1152": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001152",
         "vote_id": "2746",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1139": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001139",
         "vote_id": "2747",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1143": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001143",
         "vote_id": "2748",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1138": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001138",
         "vote_id": "2749",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27623"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2460": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002460",
         "vote_id": "275",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1221/AN/17": {
         "amendement_id": "AMANR5L16PO791932B1221P0D1N000017",
         "vote_id": "2751",
-        "dossier_id": "DLR5L16N47806"
+        "dossier_id": "DLR5L16N47806",
+        "seance_id": "RUANR5L16S2024IDS27637"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1221/AN/18": {
         "amendement_id": "AMANR5L16PO791932B1221P0D1N000018",
         "vote_id": "2752",
-        "dossier_id": "DLR5L16N47806"
+        "dossier_id": "DLR5L16N47806",
+        "seance_id": "RUANR5L16S2024IDS27637"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1221/AN/14": {
         "amendement_id": "AMANR5L16PO791932B1221P0D1N000014",
         "vote_id": "2754",
-        "dossier_id": "DLR5L16N47806"
+        "dossier_id": "DLR5L16N47806",
+        "seance_id": "RUANR5L16S2024IDS27637"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/676": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000676",
         "vote_id": "2759",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/31": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000031",
         "vote_id": "276",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1048": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001048",
         "vote_id": "2761",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/684": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000684",
         "vote_id": "2762",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/683": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000683",
         "vote_id": "2763",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1140": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001140",
         "vote_id": "2765",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3128": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003128",
         "vote_id": "277",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26392"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/709": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000709",
         "vote_id": "2771",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27634"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/138": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000138",
         "vote_id": "2772",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/989": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000989",
         "vote_id": "2773",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/700": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000700",
         "vote_id": "2774",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/661": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000661",
         "vote_id": "2775",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/970": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000970",
         "vote_id": "2776",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/697": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000697",
         "vote_id": "2777",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/698": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000698",
         "vote_id": "2778",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1046": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001046",
         "vote_id": "2779",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/646": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000646",
         "vote_id": "278",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/712": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000712",
         "vote_id": "2780",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/713": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000713",
         "vote_id": "2781",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/897": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000897",
         "vote_id": "2783",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1013": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001013",
         "vote_id": "2785",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/849": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000849",
         "vote_id": "2786",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1163": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001163",
         "vote_id": "2787",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/847": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000847",
         "vote_id": "2788",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/1016": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N001016",
         "vote_id": "2789",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2692": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002692",
         "vote_id": "279",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1674/AN/668": {
         "amendement_id": "AMANR5L16PO791932BTC1674P0D1N000668",
         "vote_id": "2790",
-        "dossier_id": "DLR5L16N47884"
+        "dossier_id": "DLR5L16N47884",
+        "seance_id": "RUANR5L16S2024IDS27635"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/106": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000106",
         "vote_id": "28",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3023": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003023",
         "vote_id": "280",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1451": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001451",
         "vote_id": "281",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/165": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N000165",
         "vote_id": "2811",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/3009": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N003009",
         "vote_id": "2812",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/1352": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N001352",
         "vote_id": "2814",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/1363": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N001363",
         "vote_id": "2815",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/3083": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N003083",
         "vote_id": "2816",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/1569": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N001569",
         "vote_id": "2818",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/2177": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N002177",
         "vote_id": "2819",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27717"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1452": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001452",
         "vote_id": "282",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/305": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N000305",
         "vote_id": "2820",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27718"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/1570": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N001570",
         "vote_id": "2822",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27718"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/1523": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N001523",
         "vote_id": "2823",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27718"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1682/AN/3330": {
         "amendement_id": "AMANR5L16PO791932B1682P0D1N003330",
         "vote_id": "2824",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27718"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1530": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001530",
         "vote_id": "2825",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27674"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/787": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000787",
         "vote_id": "2826",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27674"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/88": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000088",
         "vote_id": "2827",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27674"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/597": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000597",
         "vote_id": "2828",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27678"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1014": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001014",
         "vote_id": "2829",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27678"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3129": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003129",
         "vote_id": "283",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1032": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001032",
         "vote_id": "2831",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27678"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1034": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001034",
         "vote_id": "2832",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27678"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1038": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001038",
         "vote_id": "2833",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27678"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1831": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001831",
         "vote_id": "2835",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27681"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/930": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000930",
         "vote_id": "2836",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27681"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1832": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001832",
         "vote_id": "2837",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27681"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1833": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001833",
         "vote_id": "2838",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27681"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1122": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001122",
         "vote_id": "284",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1455": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001455",
         "vote_id": "2840",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1822": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001822",
         "vote_id": "2841",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/697": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000697",
         "vote_id": "2842",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1844": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001844",
         "vote_id": "2843",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1855": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001855",
         "vote_id": "2844",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1860": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001860",
         "vote_id": "2845",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1856": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001856",
         "vote_id": "2846",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/770": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000770",
         "vote_id": "2847",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/670": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000670",
         "vote_id": "2848",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/771": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000771",
         "vote_id": "2849",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3402": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003402",
         "vote_id": "285",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1435": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001435",
         "vote_id": "2850",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1436": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001436",
         "vote_id": "2851",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1456": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001456",
         "vote_id": "2852",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1839": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001839",
         "vote_id": "2853",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1449": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001449",
         "vote_id": "2854",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27683"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1825": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001825",
         "vote_id": "2855",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1440": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001440",
         "vote_id": "2856",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1837": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001837",
         "vote_id": "2857",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1875": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001875",
         "vote_id": "2858",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2018": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002018",
         "vote_id": "286",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/699": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000699",
         "vote_id": "2860",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/673": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000673",
         "vote_id": "2861",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2450": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002450",
         "vote_id": "2862",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27690"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1939": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001939",
         "vote_id": "2863",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27690"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1966": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001966",
         "vote_id": "2864",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27690"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1968": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001968",
         "vote_id": "2865",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27690"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1104": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001104",
         "vote_id": "2866",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1708": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001708",
         "vote_id": "2867",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/182": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000182",
         "vote_id": "2868",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1102": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001102",
         "vote_id": "2869",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2258": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002258",
         "vote_id": "287",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1146": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001146",
         "vote_id": "2870",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1728": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001728",
         "vote_id": "2871",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/944": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000944",
         "vote_id": "2872",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/129": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000129",
         "vote_id": "2873",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/130": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000130",
         "vote_id": "2874",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1097": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001097",
         "vote_id": "2875",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1133": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001133",
         "vote_id": "2876",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1120": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001120",
         "vote_id": "2877",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1761": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001761",
         "vote_id": "2878",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1237": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001237",
         "vote_id": "2879",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3383": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003383",
         "vote_id": "288",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1126": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001126",
         "vote_id": "2880",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1599": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001599",
         "vote_id": "2881",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1724": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001724",
         "vote_id": "2882",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1235": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001235",
         "vote_id": "2883",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2187": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002187",
         "vote_id": "2884",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1634": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001634",
         "vote_id": "2885",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1863": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001863",
         "vote_id": "2886",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2921": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002921",
         "vote_id": "2888",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1204": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001204",
         "vote_id": "2889",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/402": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000402",
         "vote_id": "289",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3552": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003552",
         "vote_id": "2890",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3546": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003546",
         "vote_id": "2891",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/4149": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N004149",
         "vote_id": "2892",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/349": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000349",
         "vote_id": "2893",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3421": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003421",
         "vote_id": "2894",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2601": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002601",
         "vote_id": "2895",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3384": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003384",
         "vote_id": "2896",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3145": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003145",
         "vote_id": "2897",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3146": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003146",
         "vote_id": "2898",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27694"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3331": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003331",
         "vote_id": "2899",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/332": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000332",
         "vote_id": "29",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3131": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003131",
         "vote_id": "290",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26393"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2571": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002571",
         "vote_id": "2900",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/358": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000358",
         "vote_id": "2901",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3368": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003368",
         "vote_id": "2902",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/604": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000604",
         "vote_id": "2903",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/605": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N000605",
         "vote_id": "2904",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3386": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003386",
         "vote_id": "2905",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3311": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003311",
         "vote_id": "2906",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27696"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/4006": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N004006",
         "vote_id": "2907",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27698"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/4004": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N004004",
         "vote_id": "2908",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27698"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3070": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003070",
         "vote_id": "2909",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3808": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003808",
         "vote_id": "2910",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3072": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003072",
         "vote_id": "2911",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3074": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003074",
         "vote_id": "2912",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/3114": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N003114",
         "vote_id": "2913",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2704": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002704",
         "vote_id": "2914",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1256": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001256",
         "vote_id": "2915",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1981": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001981",
         "vote_id": "2916",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1992": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001992",
         "vote_id": "2917",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2706": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002706",
         "vote_id": "2918",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2707": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002707",
         "vote_id": "2919",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1987": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001987",
         "vote_id": "2920",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/4015": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N004015",
         "vote_id": "2921",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/1984": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N001984",
         "vote_id": "2922",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1680C/AN/2814": {
         "amendement_id": "AMANR5L16PO791932B1680P2D1N002814",
         "vote_id": "2923",
-        "dossier_id": "DLR5L16N48397"
+        "dossier_id": "DLR5L16N48397",
+        "seance_id": "RUANR5L16S2024IDS27701"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/7": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000007",
         "vote_id": "2924",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/8": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000008",
         "vote_id": "2925",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/136": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000136",
         "vote_id": "2926",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/79": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000079",
         "vote_id": "2927",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/97": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000097",
         "vote_id": "2928",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/192": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000192",
         "vote_id": "2929",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/191": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000191",
         "vote_id": "2930",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/16": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000016",
         "vote_id": "2931",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/177": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000177",
         "vote_id": "2932",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/134": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000134",
         "vote_id": "2933",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/33": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000033",
         "vote_id": "2934",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/204": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000204",
         "vote_id": "2935",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/127": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000127",
         "vote_id": "2936",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/188": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000188",
         "vote_id": "2937",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/178": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000178",
         "vote_id": "2938",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/125": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000125",
         "vote_id": "2939",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/202": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000202",
         "vote_id": "2940",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/186": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000186",
         "vote_id": "2941",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1818/AN/133": {
         "amendement_id": "AMANR5L16PO791932B1818P0D1N000133",
         "vote_id": "2942",
-        "dossier_id": "DLR5L16N48839"
+        "dossier_id": "DLR5L16N48839",
+        "seance_id": "RUANR5L16S2024IDS27703"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000018",
         "vote_id": "2945",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000001",
         "vote_id": "2946",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000016",
         "vote_id": "2947",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000013",
         "vote_id": "2948",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000027",
         "vote_id": "2949",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3224": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003224",
         "vote_id": "295",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000014",
         "vote_id": "2950",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000017",
         "vote_id": "2951",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000021",
         "vote_id": "2952",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000026",
         "vote_id": "2953",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000007",
         "vote_id": "2954",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1837/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC1837P0D1N000022",
         "vote_id": "2957",
-        "dossier_id": "DLR5L16N47720"
+        "dossier_id": "DLR5L16N47720",
+        "seance_id": "RUANR5L16S2024IDS27671"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1697/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1697P0D1N000009",
         "vote_id": "2959",
-        "dossier_id": "DLR5L16N46864"
+        "dossier_id": "DLR5L16N46864",
+        "seance_id": "RUANR5L16S2024IDS27672"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/37": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000037",
         "vote_id": "296",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1697/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1697P0D1N000002",
         "vote_id": "2961",
-        "dossier_id": "DLR5L16N46864"
+        "dossier_id": "DLR5L16N46864",
+        "seance_id": "RUANR5L16S2024IDS27672"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/123": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000123",
         "vote_id": "2968",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/122": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000122",
         "vote_id": "2969",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/491": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000491",
         "vote_id": "297",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/116": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000116",
         "vote_id": "2971",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000054",
         "vote_id": "2972",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000038",
         "vote_id": "2974",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000017",
         "vote_id": "2976",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000032",
         "vote_id": "2977",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000021",
         "vote_id": "2979",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/551": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000551",
         "vote_id": "298",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000019",
         "vote_id": "2980",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1779/AN/80": {
         "amendement_id": "AMANR5L16PO791932BTC1779P0D1N000080",
         "vote_id": "2981",
-        "dossier_id": "DLR5L16N47755"
+        "dossier_id": "DLR5L16N47755",
+        "seance_id": "RUANR5L16S2024IDS27675"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1701/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1701P0D1N000005",
         "vote_id": "2986",
-        "dossier_id": "DLR5L16N47781"
+        "dossier_id": "DLR5L16N47781",
+        "seance_id": "RUANR5L16S2024IDS27676"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/202": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000202",
         "vote_id": "299",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1381": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001381",
         "vote_id": "2990",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27688"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/367": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000367",
         "vote_id": "2991",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27688"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1404": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001404",
         "vote_id": "2993",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27688"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000054",
         "vote_id": "2995",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27689"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1309": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001309",
         "vote_id": "2996",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27689"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/948": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000948",
         "vote_id": "2998",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27689"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/682": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000682",
         "vote_id": "30",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/424": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000424",
         "vote_id": "300",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000012",
         "vote_id": "3000",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27689"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1390": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001390",
         "vote_id": "3001",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27838"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/681": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000681",
         "vote_id": "3003",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27838"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/1200": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N001200",
         "vote_id": "3004",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27838"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/661": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000661",
         "vote_id": "3005",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27838"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/873": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000873",
         "vote_id": "3006",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27838"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/987": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000987",
         "vote_id": "301",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000026",
         "vote_id": "3012",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27839"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000001",
         "vote_id": "3013",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27839"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000056",
         "vote_id": "3014",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27840"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000031",
         "vote_id": "3016",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27840"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3133": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003133",
         "vote_id": "302",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000007",
         "vote_id": "3020",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27840"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000039",
         "vote_id": "3022",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27840"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1838/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1838P0D1N000065",
         "vote_id": "3023",
-        "dossier_id": "DLR5L16N48696"
+        "dossier_id": "DLR5L16N48696",
+        "seance_id": "RUANR5L16S2024IDS27840"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/631": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000631",
         "vote_id": "303",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26395"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1898/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC1898P0D1N000001",
         "vote_id": "3031",
-        "dossier_id": "DLR5L16N48925"
+        "dossier_id": "DLR5L16N48925",
+        "seance_id": "RUANR5L16S2024IDS27841"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1898/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1898P0D1N000002",
         "vote_id": "3032",
-        "dossier_id": "DLR5L16N48925"
+        "dossier_id": "DLR5L16N48925",
+        "seance_id": "RUANR5L16S2024IDS27841"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1898/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1898P0D1N000003",
         "vote_id": "3033",
-        "dossier_id": "DLR5L16N48925"
+        "dossier_id": "DLR5L16N48925",
+        "seance_id": "RUANR5L16S2024IDS27841"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1070/AN/953": {
         "amendement_id": "AMANR5L16PO791932BTC1070P0D1N000953",
         "vote_id": "3043",
-        "dossier_id": "DLR5L16N46868"
+        "dossier_id": "DLR5L16N46868",
+        "seance_id": "RUANR5L16S2024IDS27842"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1875/AN/1": {
         "amendement_id": "AMANR5L16PO791932B1875P0D1N000001",
         "vote_id": "3044",
-        "dossier_id": "DLR5L16N48683"
+        "dossier_id": "DLR5L16N48683",
+        "seance_id": "RUANR5L16S2024IDS27842"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000002",
         "vote_id": "3051",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000047",
         "vote_id": "3052",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000003",
         "vote_id": "3053",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000030",
         "vote_id": "3054",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000004",
         "vote_id": "3055",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000008",
         "vote_id": "3056",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/83": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000083",
         "vote_id": "3057",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000033",
         "vote_id": "3058",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000039",
         "vote_id": "3059",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000012",
         "vote_id": "3060",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000011",
         "vote_id": "3061",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000048",
         "vote_id": "3062",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/82": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000082",
         "vote_id": "3063",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000042",
         "vote_id": "3064",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000016",
         "vote_id": "3065",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000059",
         "vote_id": "3066",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/45": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000045",
         "vote_id": "3068",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000005",
         "vote_id": "3069",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000052",
         "vote_id": "3070",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000006",
         "vote_id": "3071",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/81": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000081",
         "vote_id": "3072",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000017",
         "vote_id": "3073",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/79": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000079",
         "vote_id": "3074",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/80": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000080",
         "vote_id": "3075",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000009",
         "vote_id": "3076",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000010",
         "vote_id": "3077",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1526/AN/36": {
         "amendement_id": "AMANR5L16PO791932BTC1526P0D1N000036",
         "vote_id": "3078",
-        "dossier_id": "DLR5L16N48208"
+        "dossier_id": "DLR5L16N48208",
+        "seance_id": "RUANR5L16S2024IDS27862"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/53": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000053",
         "vote_id": "3082",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000011",
         "vote_id": "3084",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000014",
         "vote_id": "3085",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000024",
         "vote_id": "3086",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/29": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000029",
         "vote_id": "3087",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000021",
         "vote_id": "3088",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27865"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1766/AN/22": {
         "amendement_id": "AMANR5L16PO791932B1766P0D1N000022",
         "vote_id": "3089",
-        "dossier_id": "DLR5L16N48755"
+        "dossier_id": "DLR5L16N48755",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1766/AN/26": {
         "amendement_id": "AMANR5L16PO791932B1766P0D1N000026",
         "vote_id": "3090",
-        "dossier_id": "DLR5L16N48755"
+        "dossier_id": "DLR5L16N48755",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000027",
         "vote_id": "3091",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000044",
         "vote_id": "3092",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000031",
         "vote_id": "3093",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/69": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000069",
         "vote_id": "3095",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000008",
         "vote_id": "3096",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1766/AN/56": {
         "amendement_id": "AMANR5L16PO791932B1766P0D1N000056",
         "vote_id": "3097",
-        "dossier_id": "DLR5L16N48755"
+        "dossier_id": "DLR5L16N48755",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1905/AN/60": {
         "amendement_id": "AMANR5L16PO791932BTC1905P0D1N000060",
         "vote_id": "3099",
-        "dossier_id": "DLR5L16N48766"
+        "dossier_id": "DLR5L16N48766",
+        "seance_id": "RUANR5L16S2024IDS27866"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/617": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000617",
         "vote_id": "31",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/3": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000003",
         "vote_id": "3103",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/2": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000002",
         "vote_id": "3104",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/1": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000001",
         "vote_id": "3105",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/7": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000007",
         "vote_id": "3106",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/9": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000009",
         "vote_id": "3108",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/10": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000010",
         "vote_id": "3109",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/11": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000011",
         "vote_id": "3110",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/12": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000012",
         "vote_id": "3111",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/13": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000013",
         "vote_id": "3112",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1773/AN/14": {
         "amendement_id": "AMANR5L16PO791932B1773P0D1N000014",
         "vote_id": "3114",
-        "dossier_id": "DLR5L16N48763"
+        "dossier_id": "DLR5L16N48763",
+        "seance_id": "RUANR5L16S2024IDS27867"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1874/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC1874P0D1N000008",
         "vote_id": "3121",
-        "dossier_id": "DLR5L16N47032"
+        "dossier_id": "DLR5L16N47032",
+        "seance_id": "RUANR5L16S2024IDS27897"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1874/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC1874P0D1N000009",
         "vote_id": "3122",
-        "dossier_id": "DLR5L16N47032"
+        "dossier_id": "DLR5L16N47032",
+        "seance_id": "RUANR5L16S2024IDS27897"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1911/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC1911P0D1N000048",
         "vote_id": "3130",
-        "dossier_id": "DLR5L16N47629"
+        "dossier_id": "DLR5L16N47629",
+        "seance_id": "RUANR5L16S2024IDS27898"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1911/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1911P0D1N000004",
         "vote_id": "3132",
-        "dossier_id": "DLR5L16N47629"
+        "dossier_id": "DLR5L16N47629",
+        "seance_id": "RUANR5L16S2024IDS27899"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1903/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC1903P0D1N000046",
         "vote_id": "3137",
-        "dossier_id": "DLR5L16N48312"
+        "dossier_id": "DLR5L16N48312",
+        "seance_id": "RUANR5L16S2024IDS27901"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1903/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC1903P0D1N000019",
         "vote_id": "3138",
-        "dossier_id": "DLR5L16N48312"
+        "dossier_id": "DLR5L16N48312",
+        "seance_id": "RUANR5L16S2024IDS27901"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1903/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC1903P0D1N000024",
         "vote_id": "3140",
-        "dossier_id": "DLR5L16N48312"
+        "dossier_id": "DLR5L16N48312",
+        "seance_id": "RUANR5L16S2024IDS27901"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1903/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC1903P0D1N000010",
         "vote_id": "3142",
-        "dossier_id": "DLR5L16N48312"
+        "dossier_id": "DLR5L16N48312",
+        "seance_id": "RUANR5L16S2024IDS27901"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000033",
         "vote_id": "3146",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000032",
         "vote_id": "3147",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000031",
         "vote_id": "3148",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000049",
         "vote_id": "3149",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2282": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002282",
         "vote_id": "315",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/81": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000081",
         "vote_id": "3150",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/84": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000084",
         "vote_id": "3153",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/92": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000092",
         "vote_id": "3154",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/85": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000085",
         "vote_id": "3155",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/97": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000097",
         "vote_id": "3156",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/29": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000029",
         "vote_id": "3157",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/136": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000136",
         "vote_id": "3158",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/109": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000109",
         "vote_id": "3159",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/480": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000480",
         "vote_id": "316",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000028",
         "vote_id": "3160",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/34": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000034",
         "vote_id": "3161",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000054",
         "vote_id": "3162",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000039",
         "vote_id": "3163",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/59": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000059",
         "vote_id": "3164",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/88": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000088",
         "vote_id": "3165",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000004",
         "vote_id": "3168",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000030",
         "vote_id": "3169",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2829": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002829",
         "vote_id": "317",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/90": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000090",
         "vote_id": "3170",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/64": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000064",
         "vote_id": "3172",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000010",
         "vote_id": "3173",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000065",
         "vote_id": "3174",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000067",
         "vote_id": "3175",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000068",
         "vote_id": "3176",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000011",
         "vote_id": "3177",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/105": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000105",
         "vote_id": "3178",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000016",
         "vote_id": "3179",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3251": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003251",
         "vote_id": "318",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000015",
         "vote_id": "3180",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000014",
         "vote_id": "3181",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/46": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000046",
         "vote_id": "3182",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS27902"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/55": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000055",
         "vote_id": "3184",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/68": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000068",
         "vote_id": "3185",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/18": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000018",
         "vote_id": "3186",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/20": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000020",
         "vote_id": "3187",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3248": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003248",
         "vote_id": "319",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/2": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000002",
         "vote_id": "3190",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/21": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000021",
         "vote_id": "3193",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1322/AN/120": {
         "amendement_id": "AMANR5L16PO791932B1322P0D1N000120",
         "vote_id": "3194",
-        "dossier_id": "DLR5L16N48135"
+        "dossier_id": "DLR5L16N48135",
+        "seance_id": "RUANR5L16S2024IDS27904"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1930/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC1930P0D1N000038",
         "vote_id": "3197",
-        "dossier_id": "DLR5L16N48758"
+        "dossier_id": "DLR5L16N48758",
+        "seance_id": "RUANR5L16S2024IDS27905"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1930/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC1930P0D1N000033",
         "vote_id": "3198",
-        "dossier_id": "DLR5L16N48758"
+        "dossier_id": "DLR5L16N48758",
+        "seance_id": "RUANR5L16S2024IDS27905"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2466": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002466",
         "vote_id": "320",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1930/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC1930P0D1N000043",
         "vote_id": "3200",
-        "dossier_id": "DLR5L16N48758"
+        "dossier_id": "DLR5L16N48758",
+        "seance_id": "RUANR5L16S2024IDS27905"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3249": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003249",
         "vote_id": "321",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26397"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2451": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002451",
         "vote_id": "322",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/100": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000100",
         "vote_id": "3221",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28007"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000061",
         "vote_id": "3224",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28007"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/159": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000159",
         "vote_id": "3225",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28007"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000002",
         "vote_id": "3226",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28007"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000066",
         "vote_id": "3229",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28008"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1760": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001760",
         "vote_id": "323",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000004",
         "vote_id": "3230",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28008"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/327": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000327",
         "vote_id": "3232",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28008"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/269": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000269",
         "vote_id": "3233",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28008"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/101": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000101",
         "vote_id": "3237",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28008"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/158": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000158",
         "vote_id": "3239",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1744": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001744",
         "vote_id": "324",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000008",
         "vote_id": "3240",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/193": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000193",
         "vote_id": "3241",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/278": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000278",
         "vote_id": "3242",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/184": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000184",
         "vote_id": "3244",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/181": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000181",
         "vote_id": "3245",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28009"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2066/AN/285": {
         "amendement_id": "AMANR5L16PO791932BTC2066P0D1N000285",
         "vote_id": "3246",
-        "dossier_id": "DLR5L16N49096"
+        "dossier_id": "DLR5L16N49096",
+        "seance_id": "RUANR5L16S2024IDS28010"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2657": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002657",
         "vote_id": "325",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/53": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000053",
         "vote_id": "3252",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/115": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000115",
         "vote_id": "3253",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000003",
         "vote_id": "3265",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/36": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000036",
         "vote_id": "3258",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000035",
         "vote_id": "3259",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1039": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001039",
         "vote_id": "326",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000017",
         "vote_id": "3260",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000048",
         "vote_id": "3262",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/41": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000041",
         "vote_id": "3263",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000063",
         "vote_id": "3264",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000067",
         "vote_id": "3266",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/45": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000045",
         "vote_id": "3267",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000062",
         "vote_id": "3268",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1928/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC1928P0D1N000070",
         "vote_id": "3269",
-        "dossier_id": "DLR5L16N47722"
+        "dossier_id": "DLR5L16N47722",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2467": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002467",
         "vote_id": "327",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000042",
         "vote_id": "3270",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28028"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000001",
         "vote_id": "3271",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000071",
         "vote_id": "3272",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000065",
         "vote_id": "3273",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/89": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000089",
         "vote_id": "3274",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/64": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000064",
         "vote_id": "3275",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000047",
         "vote_id": "3278",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000038",
         "vote_id": "3279",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2663": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002663",
         "vote_id": "328",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/86": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000086",
         "vote_id": "3280",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000061",
         "vote_id": "3283",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000044",
         "vote_id": "3285",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000043",
         "vote_id": "3286",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2109/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2109P0D1N000008",
         "vote_id": "3287",
-        "dossier_id": "DLR5L16N47797"
+        "dossier_id": "DLR5L16N47797",
+        "seance_id": "RUANR5L16S2024IDS28029"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/442": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000442",
         "vote_id": "329",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2104/AN/88": {
         "amendement_id": "AMANR5L16PO791932BTC2104P0D1N000088",
         "vote_id": "3290",
-        "dossier_id": "DLR5L16N48739"
+        "dossier_id": "DLR5L16N48739",
+        "seance_id": "RUANR5L16S2024IDS28032"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2104/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC2104P0D1N000042",
         "vote_id": "3291",
-        "dossier_id": "DLR5L16N48739"
+        "dossier_id": "DLR5L16N48739",
+        "seance_id": "RUANR5L16S2024IDS28032"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2104/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC2104P0D1N000014",
         "vote_id": "3292",
-        "dossier_id": "DLR5L16N48739"
+        "dossier_id": "DLR5L16N48739",
+        "seance_id": "RUANR5L16S2024IDS28032"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2104/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC2104P0D1N000015",
         "vote_id": "3293",
-        "dossier_id": "DLR5L16N48739"
+        "dossier_id": "DLR5L16N48739",
+        "seance_id": "RUANR5L16S2024IDS28032"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2104/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC2104P0D1N000016",
         "vote_id": "3294",
-        "dossier_id": "DLR5L16N48739"
+        "dossier_id": "DLR5L16N48739",
+        "seance_id": "RUANR5L16S2024IDS28032"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1925/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC1925P0D1N000027",
         "vote_id": "3298",
-        "dossier_id": "DLR5L16N48422"
+        "dossier_id": "DLR5L16N48422",
+        "seance_id": "RUANR5L16S2024IDS28038"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1063": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001063",
         "vote_id": "330",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1925/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC1925P0D1N000055",
         "vote_id": "3300",
-        "dossier_id": "DLR5L16N48422"
+        "dossier_id": "DLR5L16N48422",
+        "seance_id": "RUANR5L16S2024IDS28038"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/1925/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC1925P0D1N000062",
         "vote_id": "3303",
-        "dossier_id": "DLR5L16N48422"
+        "dossier_id": "DLR5L16N48422",
+        "seance_id": "RUANR5L16S2024IDS28038"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/139": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000139",
         "vote_id": "3306",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28034"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/149": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000149",
         "vote_id": "3307",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28034"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000093",
         "vote_id": "3308",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28034"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000031",
         "vote_id": "3309",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/553": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000553",
         "vote_id": "331",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26398"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/134": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000134",
         "vote_id": "3310",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/100": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000100",
         "vote_id": "3311",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000011",
         "vote_id": "3312",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/179": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000179",
         "vote_id": "3314",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/109": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000109",
         "vote_id": "3315",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28035"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/160": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000160",
         "vote_id": "3316",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/136": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000136",
         "vote_id": "3317",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000111",
         "vote_id": "3318",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1834": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001834",
         "vote_id": "332",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000018",
         "vote_id": "3320",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/115": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000115",
         "vote_id": "3321",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000048",
         "vote_id": "3324",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/126": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000126",
         "vote_id": "3325",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000039",
         "vote_id": "3326",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/88": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000088",
         "vote_id": "3327",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/215": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000215",
         "vote_id": "3328",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/50": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000050",
         "vote_id": "3329",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3054": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003054",
         "vote_id": "333",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/135": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000135",
         "vote_id": "3330",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2112/AN/138": {
         "amendement_id": "AMANR5L16PO791932BTC2112P0D1N000138",
         "vote_id": "3331",
-        "dossier_id": "DLR5L15N45886"
+        "dossier_id": "DLR5L15N45886",
+        "seance_id": "RUANR5L16S2024IDS28036"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/36": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000036",
         "vote_id": "3337",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000017",
         "vote_id": "3338",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28058"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1450": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001450",
         "vote_id": "334",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000032",
         "vote_id": "3340",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28059"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000039",
         "vote_id": "3342",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28059"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/45": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000045",
         "vote_id": "3343",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28059"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000001",
         "vote_id": "3345",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/25": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000025",
         "vote_id": "3346",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000027",
         "vote_id": "3347",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/42": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000042",
         "vote_id": "3348",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2139/AN/101": {
         "amendement_id": "AMANR5L16PO791932BTC2139P0D1N000101",
         "vote_id": "3349",
-        "dossier_id": "DLR5L16N48018"
+        "dossier_id": "DLR5L16N48018",
+        "seance_id": "RUANR5L16S2024IDS28060"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3209": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003209",
         "vote_id": "335",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000024",
         "vote_id": "3351",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/51": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000051",
         "vote_id": "3352",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000001",
         "vote_id": "3353",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/121": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000121",
         "vote_id": "3354",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/99": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000099",
         "vote_id": "3355",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/156": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000156",
         "vote_id": "3356",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/165": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000165",
         "vote_id": "3357",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/108": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000108",
         "vote_id": "3359",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28078"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3210": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003210",
         "vote_id": "336",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/113": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000113",
         "vote_id": "3362",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2157/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC2157P0D1N000030",
         "vote_id": "3363",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28079"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2077/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC2077P0D1N000003",
         "vote_id": "3367",
-        "dossier_id": "DLR5L16N49021"
+        "dossier_id": "DLR5L16N49021",
+        "seance_id": "RUANR5L16S2024IDS28080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2077/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC2077P0D1N000002",
         "vote_id": "3369",
-        "dossier_id": "DLR5L16N49021"
+        "dossier_id": "DLR5L16N49021",
+        "seance_id": "RUANR5L16S2024IDS28080"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2648": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002648",
         "vote_id": "337",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26399"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2201/AN/43": {
         "amendement_id": "AMANR5L16PO791932BTC2201P0D1N000043",
         "vote_id": "3372",
-        "dossier_id": "DLR5L16N46921"
+        "dossier_id": "DLR5L16N46921",
+        "seance_id": "RUANR5L16S2024IDS28085"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2206/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC2206P0D1N000014",
         "vote_id": "3375",
-        "dossier_id": "DLR5L16N49263"
+        "dossier_id": "DLR5L16N49263",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2204/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC2204P0D1N000018",
         "vote_id": "3384",
-        "dossier_id": "DLR5L16N49258"
+        "dossier_id": "DLR5L16N49258",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2206/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2206P0D1N000001",
         "vote_id": "3377",
-        "dossier_id": "DLR5L16N49263"
+        "dossier_id": "DLR5L16N49263",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2204/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC2204P0D1N000002",
         "vote_id": "3378",
-        "dossier_id": "DLR5L16N49258"
+        "dossier_id": "DLR5L16N49258",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2204/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC2204P0D1N000022",
         "vote_id": "3379",
-        "dossier_id": "DLR5L16N49258"
+        "dossier_id": "DLR5L16N49258",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2204/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC2204P0D1N000006",
         "vote_id": "3381",
-        "dossier_id": "DLR5L16N49258"
+        "dossier_id": "DLR5L16N49258",
+        "seance_id": "RUANR5L16S2024IDS28086"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2214/AN/145": {
         "amendement_id": "AMANR5L16PO791932BTC2214P0D1N000145",
         "vote_id": "3386",
-        "dossier_id": "DLR5L16N49261"
+        "dossier_id": "DLR5L16N49261",
+        "seance_id": "RUANR5L16S2024IDS28087"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2214/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC2214P0D1N000096",
         "vote_id": "3387",
-        "dossier_id": "DLR5L16N49261"
+        "dossier_id": "DLR5L16N49261",
+        "seance_id": "RUANR5L16S2024IDS28087"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2214/AN/116": {
         "amendement_id": "AMANR5L16PO791932BTC2214P0D1N000116",
         "vote_id": "3389",
-        "dossier_id": "DLR5L16N49261"
+        "dossier_id": "DLR5L16N49261",
+        "seance_id": "RUANR5L16S2024IDS28087"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3339": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003339",
         "vote_id": "339",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26400"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2214/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC2214P0D1N000015",
         "vote_id": "3390",
-        "dossier_id": "DLR5L16N49261"
+        "dossier_id": "DLR5L16N49261",
+        "seance_id": "RUANR5L16S2024IDS28087"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/915": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000915",
         "vote_id": "34",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26207"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1562": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001562",
         "vote_id": "340",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26400"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2078/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC2078P0D1N000022",
         "vote_id": "3408",
-        "dossier_id": "DLR5L16N49029"
+        "dossier_id": "DLR5L16N49029",
+        "seance_id": "RUANR5L16S2024IDS28118"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/2012": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N002012",
         "vote_id": "341",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2078/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC2078P0D1N000011",
         "vote_id": "3410",
-        "dossier_id": "DLR5L16N49029"
+        "dossier_id": "DLR5L16N49029",
+        "seance_id": "RUANR5L16S2024IDS28118"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000018",
         "vote_id": "3412",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000055",
         "vote_id": "3414",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/62": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000062",
         "vote_id": "3415",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000056",
         "vote_id": "3416",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000057",
         "vote_id": "3417",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000072",
         "vote_id": "3418",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/34": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000034",
         "vote_id": "3419",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/1956": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N001956",
         "vote_id": "342",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000016",
         "vote_id": "3421",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000012",
         "vote_id": "3422",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000009",
         "vote_id": "3425",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000011",
         "vote_id": "3426",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000013",
         "vote_id": "3427",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000008",
         "vote_id": "3428",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000010",
         "vote_id": "3429",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/113": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000113",
         "vote_id": "343",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2246/AN/17": {
         "amendement_id": "AMANR5L16PO791932BTC2246P0D1N000017",
         "vote_id": "3430",
-        "dossier_id": "DLR5L16N48646"
+        "dossier_id": "DLR5L16N48646",
+        "seance_id": "RUANR5L16S2024IDS28119"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2247/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC2247P0D1N000033",
         "vote_id": "3433",
-        "dossier_id": "DLR5L16N46127"
+        "dossier_id": "DLR5L16N46127",
+        "seance_id": "RUANR5L16S2024IDS28121"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2247/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC2247P0D1N000040",
         "vote_id": "3434",
-        "dossier_id": "DLR5L16N46127"
+        "dossier_id": "DLR5L16N46127",
+        "seance_id": "RUANR5L16S2024IDS28121"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2247/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC2247P0D1N000010",
         "vote_id": "3435",
-        "dossier_id": "DLR5L16N46127"
+        "dossier_id": "DLR5L16N46127",
+        "seance_id": "RUANR5L16S2024IDS28121"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000020",
         "vote_id": "3437",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000032",
         "vote_id": "3438",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000031",
         "vote_id": "3439",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/673": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000673",
         "vote_id": "344",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/23": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000023",
         "vote_id": "3440",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000038",
         "vote_id": "3442",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2111/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC2111P0D1N000003",
         "vote_id": "3444",
-        "dossier_id": "DLR5L16N49107"
+        "dossier_id": "DLR5L16N49107",
+        "seance_id": "RUANR5L16S2024IDS28122"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2245/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC2245P0D1N000005",
         "vote_id": "3446",
-        "dossier_id": "DLR5L16N47601"
+        "dossier_id": "DLR5L16N47601",
+        "seance_id": "RUANR5L16S2024IDS28123"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2245/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC2245P0D1N000033",
         "vote_id": "3447",
-        "dossier_id": "DLR5L16N47601"
+        "dossier_id": "DLR5L16N47601",
+        "seance_id": "RUANR5L16S2024IDS28123"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2245/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC2245P0D1N000044",
         "vote_id": "3448",
-        "dossier_id": "DLR5L16N47601"
+        "dossier_id": "DLR5L16N47601",
+        "seance_id": "RUANR5L16S2024IDS28123"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/111": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000111",
         "vote_id": "345",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2245/AN/39": {
         "amendement_id": "AMANR5L16PO791932BTC2245P0D1N000039",
         "vote_id": "3455",
-        "dossier_id": "DLR5L16N47601"
+        "dossier_id": "DLR5L16N47601",
+        "seance_id": "RUANR5L16S2024IDS28123"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/3140": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N003140",
         "vote_id": "346",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/171": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000171",
         "vote_id": "3460",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28138"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000033",
         "vote_id": "3462",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000068",
         "vote_id": "3463",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000032",
         "vote_id": "3464",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/352": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000352",
         "vote_id": "3465",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/331": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000331",
         "vote_id": "3466",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/112": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000112",
         "vote_id": "3467",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/93": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000093",
         "vote_id": "3468",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/117": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000117",
         "vote_id": "3469",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/193": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000193",
         "vote_id": "347",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26401"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/226": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000226",
         "vote_id": "3470",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28140"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/51": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000051",
         "vote_id": "3471",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/247": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000247",
         "vote_id": "3472",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/249": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000249",
         "vote_id": "3473",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/157": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000157",
         "vote_id": "3474",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/97": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000097",
         "vote_id": "3475",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/285": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000285",
         "vote_id": "3477",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/166": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000166",
         "vote_id": "3478",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/286": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000286",
         "vote_id": "3479",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28141"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273A/AN/201": {
         "amendement_id": "AMANR5L16PO791932B0273P1D1N000201",
         "vote_id": "348",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26402"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/332": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000332",
         "vote_id": "3482",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28145"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000013",
         "vote_id": "3483",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28145"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/327": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000327",
         "vote_id": "3484",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28145"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/281": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000281",
         "vote_id": "3485",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28145"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/236": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000236",
         "vote_id": "3488",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28145"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2307/AN/85": {
         "amendement_id": "AMANR5L16PO791932BTC2307P0D1N000085",
         "vote_id": "3491",
-        "dossier_id": "DLR5L16N49364"
+        "dossier_id": "DLR5L16N49364",
+        "seance_id": "RUANR5L16S2024IDS28143"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2307/AN/140": {
         "amendement_id": "AMANR5L16PO791932BTC2307P0D1N000140",
         "vote_id": "3492",
-        "dossier_id": "DLR5L16N49364"
+        "dossier_id": "DLR5L16N49364",
+        "seance_id": "RUANR5L16S2024IDS28143"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2307/AN/126": {
         "amendement_id": "AMANR5L16PO791932BTC2307P0D1N000126",
         "vote_id": "3493",
-        "dossier_id": "DLR5L16N49364"
+        "dossier_id": "DLR5L16N49364",
+        "seance_id": "RUANR5L16S2024IDS28143"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2307/AN/137": {
         "amendement_id": "AMANR5L16PO791932BTC2307P0D1N000137",
         "vote_id": "3494",
-        "dossier_id": "DLR5L16N49364"
+        "dossier_id": "DLR5L16N49364",
+        "seance_id": "RUANR5L16S2024IDS28143"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2296/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC2296P0D1N000002",
         "vote_id": "3500",
-        "dossier_id": "DLR5L16N49299"
+        "dossier_id": "DLR5L16N49299",
+        "seance_id": "RUANR5L16S2024IDS28144"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2296/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC2296P0D1N000006",
         "vote_id": "3503",
-        "dossier_id": "DLR5L16N49299"
+        "dossier_id": "DLR5L16N49299",
+        "seance_id": "RUANR5L16S2024IDS28144"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/165": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000165",
         "vote_id": "3515",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28218"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/330": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000330",
         "vote_id": "3517",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28218"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2305/AN/329": {
         "amendement_id": "AMANR5L16PO791932BTC2305P0D1N000329",
         "vote_id": "3519",
-        "dossier_id": "DLR5L16N49124"
+        "dossier_id": "DLR5L16N49124",
+        "seance_id": "RUANR5L16S2024IDS28218"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2300/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC2300P0D1N000009",
         "vote_id": "3523",
-        "dossier_id": "DLR5L16N49123"
+        "dossier_id": "DLR5L16N49123",
+        "seance_id": "RUANR5L16S2024IDS28218"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2331/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2331P0D1N000001",
         "vote_id": "3524",
-        "dossier_id": "DLR5L16N49374"
+        "dossier_id": "DLR5L16N49374",
+        "seance_id": "RUANR5L16S2024IDS28157"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2331/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC2331P0D1N000006",
         "vote_id": "3525",
-        "dossier_id": "DLR5L16N49374"
+        "dossier_id": "DLR5L16N49374",
+        "seance_id": "RUANR5L16S2024IDS28157"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000049",
         "vote_id": "3528",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28157"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000048",
         "vote_id": "3529",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28157"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000056",
         "vote_id": "3530",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28157"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/60": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000060",
         "vote_id": "3532",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000027",
         "vote_id": "3534",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000028",
         "vote_id": "3535",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/37": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000037",
         "vote_id": "3537",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/16": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000016",
         "vote_id": "3538",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000018",
         "vote_id": "3539",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/1112": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N001112",
         "vote_id": "354",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26405"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000003",
         "vote_id": "3541",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/90": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000090",
         "vote_id": "3542",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/84": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000084",
         "vote_id": "3543",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2334/AN/44": {
         "amendement_id": "AMANR5L16PO791932BTC2334P0D1N000044",
         "vote_id": "3544",
-        "dossier_id": "DLR5L16N48908"
+        "dossier_id": "DLR5L16N48908",
+        "seance_id": "RUANR5L16S2024IDS28158"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000024",
         "vote_id": "3551",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28160"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/33": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000033",
         "vote_id": "3552",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28160"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000075",
         "vote_id": "3553",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28160"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000019",
         "vote_id": "3555",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/34": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000034",
         "vote_id": "3556",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/86": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000086",
         "vote_id": "3557",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/55": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000055",
         "vote_id": "3558",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/85": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000085",
         "vote_id": "3559",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/914": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000914",
         "vote_id": "356",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26405"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000008",
         "vote_id": "3563",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2333/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC2333P0D1N000007",
         "vote_id": "3564",
-        "dossier_id": "DLR5L16N48909"
+        "dossier_id": "DLR5L16N48909",
+        "seance_id": "RUANR5L16S2024IDS28161"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000006",
         "vote_id": "3568",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28180"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/78": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000078",
         "vote_id": "3569",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28180"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000063",
         "vote_id": "3570",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28180"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/64": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000064",
         "vote_id": "3571",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28180"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/152": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000152",
         "vote_id": "3572",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28180"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/99": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000099",
         "vote_id": "3573",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/157": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000157",
         "vote_id": "3574",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/137": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000137",
         "vote_id": "3576",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000009",
         "vote_id": "3577",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000066",
         "vote_id": "3578",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000067",
         "vote_id": "3579",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/21": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000021",
         "vote_id": "3580",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28181"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/112": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000112",
         "vote_id": "3582",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/114": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000114",
         "vote_id": "3583",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/115": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000115",
         "vote_id": "3584",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/120": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000120",
         "vote_id": "3585",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2343/AN/121": {
         "amendement_id": "AMANR5L16PO791932BTC2343P0D1N000121",
         "vote_id": "3586",
-        "dossier_id": "DLR5L16N49386"
+        "dossier_id": "DLR5L16N49386",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/80": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000080",
         "vote_id": "3591",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/47": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000047",
         "vote_id": "3592",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000070",
         "vote_id": "3595",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000056",
         "vote_id": "3597",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000063",
         "vote_id": "3598",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000001",
         "vote_id": "3599",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000071",
         "vote_id": "3600",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000072",
         "vote_id": "3602",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000074",
         "vote_id": "3606",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000075",
         "vote_id": "3609",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/76": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000076",
         "vote_id": "3611",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/57": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000057",
         "vote_id": "3612",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/78": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000078",
         "vote_id": "3613",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2383/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC2383P0D1N000032",
         "vote_id": "3615",
-        "dossier_id": "DLR5L16N47586"
+        "dossier_id": "DLR5L16N47586",
+        "seance_id": "RUANR5L16S2024IDS28182"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2382/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2382P0D1N000008",
         "vote_id": "3618",
-        "dossier_id": "DLR5L16N48617"
+        "dossier_id": "DLR5L16N48617",
+        "seance_id": "RUANR5L16S2024IDS28183"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2382/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC2382P0D1N000009",
         "vote_id": "3619",
-        "dossier_id": "DLR5L16N48617"
+        "dossier_id": "DLR5L16N48617",
+        "seance_id": "RUANR5L16S2024IDS28183"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2752": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002752",
         "vote_id": "362",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26460"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2382/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC2382P0D1N000010",
         "vote_id": "3620",
-        "dossier_id": "DLR5L16N48617"
+        "dossier_id": "DLR5L16N48617",
+        "seance_id": "RUANR5L16S2024IDS28183"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2382/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC2382P0D1N000011",
         "vote_id": "3621",
-        "dossier_id": "DLR5L16N48617"
+        "dossier_id": "DLR5L16N48617",
+        "seance_id": "RUANR5L16S2024IDS28183"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000001",
         "vote_id": "3626",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000111",
         "vote_id": "3627",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/109": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000109",
         "vote_id": "3628",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000094",
         "vote_id": "3629",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2229": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002229",
         "vote_id": "363",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26460"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/87": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000087",
         "vote_id": "3630",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/82": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000082",
         "vote_id": "3632",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28204"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000075",
         "vote_id": "3634",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/122": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000122",
         "vote_id": "3635",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000095",
         "vote_id": "3636",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000066",
         "vote_id": "3637",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000072",
         "vote_id": "3639",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/595": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000595",
         "vote_id": "364",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/22": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000022",
         "vote_id": "3640",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2408/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC2408P0D1N000096",
         "vote_id": "3642",
-        "dossier_id": "DLR5L16N49455"
+        "dossier_id": "DLR5L16N49455",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/29": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000029",
         "vote_id": "3644",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/31": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000031",
         "vote_id": "3645",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/32": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000032",
         "vote_id": "3646",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000052",
         "vote_id": "3647",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28205"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/34": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000034",
         "vote_id": "3649",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/530": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000530",
         "vote_id": "365",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2403/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC2403P0D1N000063",
         "vote_id": "3650",
-        "dossier_id": "DLR5L16N49457"
+        "dossier_id": "DLR5L16N49457",
+        "seance_id": "RUANR5L16S2024IDS28206"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2431/AN/7": {
         "amendement_id": "AMANR5L16PO791932BTC2431P0D1N000007",
         "vote_id": "3658",
-        "dossier_id": "DLR5L16N48348"
+        "dossier_id": "DLR5L16N48348",
+        "seance_id": "RUANR5L16S2024IDS28223"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2431/AN/15": {
         "amendement_id": "AMANR5L16PO791932BTC2431P0D1N000015",
         "vote_id": "3659",
-        "dossier_id": "DLR5L16N48348"
+        "dossier_id": "DLR5L16N48348",
+        "seance_id": "RUANR5L16S2024IDS28223"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2129": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002129",
         "vote_id": "366",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/100": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000100",
         "vote_id": "3670",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28226"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/97": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000097",
         "vote_id": "3671",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28226"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/98": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000098",
         "vote_id": "3672",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28226"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/99": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000099",
         "vote_id": "3673",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28226"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/608": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000608",
         "vote_id": "368",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/90": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000090",
         "vote_id": "3682",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000068",
         "vote_id": "3687",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/67": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000067",
         "vote_id": "3688",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000111",
         "vote_id": "3689",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/706": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000706",
         "vote_id": "369",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/128": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000128",
         "vote_id": "3690",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000054",
         "vote_id": "3692",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000094",
         "vote_id": "3695",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000095",
         "vote_id": "3696",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2428/AN/116": {
         "amendement_id": "AMANR5L16PO791932BTC2428P0D1N000116",
         "vote_id": "3697",
-        "dossier_id": "DLR5L16N49601"
+        "dossier_id": "DLR5L16N49601",
+        "seance_id": "RUANR5L16S2024IDS28227"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/127": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000127",
         "vote_id": "37",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/708": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000708",
         "vote_id": "370",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2459/AN/4": {
         "amendement_id": "AMANR5L16PO791932BTC2459P0D1N000004",
         "vote_id": "3700",
-        "dossier_id": "DLR5L16N49296"
+        "dossier_id": "DLR5L16N49296",
+        "seance_id": "RUANR5L16S2024IDS28258"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2459/AN/37": {
         "amendement_id": "AMANR5L16PO791932BTC2459P0D1N000037",
         "vote_id": "3701",
-        "dossier_id": "DLR5L16N49296"
+        "dossier_id": "DLR5L16N49296",
+        "seance_id": "RUANR5L16S2024IDS28258"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2469/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC2469P0D1N000075",
         "vote_id": "3705",
-        "dossier_id": "DLR5L16N49138"
+        "dossier_id": "DLR5L16N49138",
+        "seance_id": "RUANR5L16S2024IDS28259"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2469/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC2469P0D1N000008",
         "vote_id": "3706",
-        "dossier_id": "DLR5L16N49138"
+        "dossier_id": "DLR5L16N49138",
+        "seance_id": "RUANR5L16S2024IDS28260"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2469/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC2469P0D1N000009",
         "vote_id": "3707",
-        "dossier_id": "DLR5L16N49138"
+        "dossier_id": "DLR5L16N49138",
+        "seance_id": "RUANR5L16S2024IDS28260"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/500": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000500",
         "vote_id": "371",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2457/AN/68": {
         "amendement_id": "AMANR5L16PO791932BTC2457P0D1N000068",
         "vote_id": "3712",
-        "dossier_id": "DLR5L16N48498"
+        "dossier_id": "DLR5L16N48498",
+        "seance_id": "RUANR5L16S2024IDS28262"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2424/AN/11": {
         "amendement_id": "AMANR5L16PO791932B2424P0D1N000011",
         "vote_id": "3718",
-        "dossier_id": "DLR5L16N49373"
+        "dossier_id": "DLR5L16N49373",
+        "seance_id": "RUANR5L16S2024IDS28319"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/484": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000484",
         "vote_id": "372",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2424/AN/51": {
         "amendement_id": "AMANR5L16PO791932B2424P0D1N000051",
         "vote_id": "3721",
-        "dossier_id": "DLR5L16N49373"
+        "dossier_id": "DLR5L16N49373",
+        "seance_id": "RUANR5L16S2024IDS28357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2424/AN/122": {
         "amendement_id": "AMANR5L16PO791932B2424P0D1N000122",
         "vote_id": "3722",
-        "dossier_id": "DLR5L16N49373"
+        "dossier_id": "DLR5L16N49373",
+        "seance_id": "RUANR5L16S2024IDS28357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2424/AN/52": {
         "amendement_id": "AMANR5L16PO791932B2424P0D1N000052",
         "vote_id": "3723",
-        "dossier_id": "DLR5L16N49373"
+        "dossier_id": "DLR5L16N49373",
+        "seance_id": "RUANR5L16S2024IDS28357"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/469": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000469",
         "vote_id": "3727",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28322"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/115": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000115",
         "vote_id": "3729",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/697": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000697",
         "vote_id": "373",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3063": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003063",
         "vote_id": "3730",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3804": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003804",
         "vote_id": "3731",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4446": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004446",
         "vote_id": "3732",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4850": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004850",
         "vote_id": "3733",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4803": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004803",
         "vote_id": "3734",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4770": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004770",
         "vote_id": "3735",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4821": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004821",
         "vote_id": "3736",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5411": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005411",
         "vote_id": "3737",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4890": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004890",
         "vote_id": "3738",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4787": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004787",
         "vote_id": "3739",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/868": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000868",
         "vote_id": "374",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5272": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005272",
         "vote_id": "3740",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5258": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005258",
         "vote_id": "3741",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5229": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005229",
         "vote_id": "3742",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5210": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005210",
         "vote_id": "3743",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4965": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004965",
         "vote_id": "3744",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5252": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005252",
         "vote_id": "3745",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5286": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005286",
         "vote_id": "3746",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5216": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005216",
         "vote_id": "3747",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5220": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005220",
         "vote_id": "3748",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5197": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005197",
         "vote_id": "3749",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/609": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000609",
         "vote_id": "375",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5231": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005231",
         "vote_id": "3750",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5058": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005058",
         "vote_id": "3751",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4817": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004817",
         "vote_id": "3752",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4937": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004937",
         "vote_id": "3753",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4946": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004946",
         "vote_id": "3754",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5127": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005127",
         "vote_id": "3755",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5140": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005140",
         "vote_id": "3756",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5143": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005143",
         "vote_id": "3757",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5144": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005144",
         "vote_id": "3758",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5145": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005145",
         "vote_id": "3759",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2212": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002212",
         "vote_id": "376",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5148": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005148",
         "vote_id": "3760",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5160": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005160",
         "vote_id": "3761",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5131": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005131",
         "vote_id": "3762",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5060": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005060",
         "vote_id": "3763",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4784": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004784",
         "vote_id": "3764",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5147": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005147",
         "vote_id": "3765",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5002": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005002",
         "vote_id": "3766",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4742": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004742",
         "vote_id": "3767",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4910": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004910",
         "vote_id": "3768",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4994": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004994",
         "vote_id": "3769",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2168": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002168",
         "vote_id": "377",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5000": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005000",
         "vote_id": "3770",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5281": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005281",
         "vote_id": "3771",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5222": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005222",
         "vote_id": "3772",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4750": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004750",
         "vote_id": "3773",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5254": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005254",
         "vote_id": "3774",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5161": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005161",
         "vote_id": "3775",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4819": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004819",
         "vote_id": "3776",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5300": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005300",
         "vote_id": "3777",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5302": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005302",
         "vote_id": "3778",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5301": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005301",
         "vote_id": "3779",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/603": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000603",
         "vote_id": "378",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26461"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5315": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005315",
         "vote_id": "3780",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5340": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005340",
         "vote_id": "3781",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5057": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005057",
         "vote_id": "3782",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5283": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005283",
         "vote_id": "3783",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5130": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005130",
         "vote_id": "3784",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4806": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004806",
         "vote_id": "3785",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5137": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005137",
         "vote_id": "3786",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5345": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005345",
         "vote_id": "3787",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5288": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005288",
         "vote_id": "3788",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4807": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004807",
         "vote_id": "3789",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/3237": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N003237",
         "vote_id": "379",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4808": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004808",
         "vote_id": "3790",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5202": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005202",
         "vote_id": "3791",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5106": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005106",
         "vote_id": "3792",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5204": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005204",
         "vote_id": "3793",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5311": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005311",
         "vote_id": "3794",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5243": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005243",
         "vote_id": "3795",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5105": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005105",
         "vote_id": "3796",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4763": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004763",
         "vote_id": "3797",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5080": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005080",
         "vote_id": "3798",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5081": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005081",
         "vote_id": "3799",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/116": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000116",
         "vote_id": "38",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/2486": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N002486",
         "vote_id": "380",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5361": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005361",
         "vote_id": "3800",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5360": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005360",
         "vote_id": "3801",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4992": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004992",
         "vote_id": "3802",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5366": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005366",
         "vote_id": "3803",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5282": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005282",
         "vote_id": "3804",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4947": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004947",
         "vote_id": "3805",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4908": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004908",
         "vote_id": "3806",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5077": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005077",
         "vote_id": "3807",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5368": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005368",
         "vote_id": "3808",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5369": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005369",
         "vote_id": "3809",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4810": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004810",
         "vote_id": "3810",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3952": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003952",
         "vote_id": "3811",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28361"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/630": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000630",
         "vote_id": "3814",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3188": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003188",
         "vote_id": "3815",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1921": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001921",
         "vote_id": "3816",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2581": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002581",
         "vote_id": "3817",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2736": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002736",
         "vote_id": "3818",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/632": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000632",
         "vote_id": "3819",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/617": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000617",
         "vote_id": "382",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/653": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000653",
         "vote_id": "3820",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2687": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002687",
         "vote_id": "3821",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1379": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001379",
         "vote_id": "3822",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28362"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4611": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004611",
         "vote_id": "3823",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1355": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001355",
         "vote_id": "3824",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1360": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001360",
         "vote_id": "3827",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1351": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001351",
         "vote_id": "3826",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1364": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001364",
         "vote_id": "3828",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2351": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002351",
         "vote_id": "3829",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/619": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000619",
         "vote_id": "383",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4358": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004358",
         "vote_id": "3830",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4365": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004365",
         "vote_id": "3831",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1975": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001975",
         "vote_id": "3832",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/832": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000832",
         "vote_id": "3833",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1367": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001367",
         "vote_id": "3834",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3967": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003967",
         "vote_id": "3835",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3884": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003884",
         "vote_id": "3836",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1985": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001985",
         "vote_id": "3837",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2569": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002569",
         "vote_id": "3838",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/838": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000838",
         "vote_id": "3839",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/1861": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N001861",
         "vote_id": "384",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1819": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001819",
         "vote_id": "3840",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5433": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005433",
         "vote_id": "3841",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4140": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004140",
         "vote_id": "3842",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/843": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000843",
         "vote_id": "3843",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28363"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3649": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003649",
         "vote_id": "3844",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2340": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002340",
         "vote_id": "3845",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4481": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004481",
         "vote_id": "3846",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/845": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000845",
         "vote_id": "3847",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/846": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000846",
         "vote_id": "3848",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/593": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000593",
         "vote_id": "385",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3650": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003650",
         "vote_id": "3850",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4375": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004375",
         "vote_id": "3851",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2366": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002366",
         "vote_id": "3852",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3824": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003824",
         "vote_id": "3853",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4619": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004619",
         "vote_id": "3854",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28364"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/873": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000873",
         "vote_id": "3855",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28365"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/657": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000657",
         "vote_id": "3856",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28365"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/916": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000916",
         "vote_id": "3857",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28365"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3093": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003093",
         "vote_id": "3858",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/1306": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N001306",
         "vote_id": "386",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/641": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000641",
         "vote_id": "3860",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/960": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000960",
         "vote_id": "3861",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2119": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002119",
         "vote_id": "3862",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2120": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002120",
         "vote_id": "3863",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2873": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002873",
         "vote_id": "3864",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2890": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002890",
         "vote_id": "3867",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28366"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2541": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002541",
         "vote_id": "3868",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4688": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004688",
         "vote_id": "3869",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/916": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000916",
         "vote_id": "387",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26462"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2897": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002897",
         "vote_id": "3870",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2900": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002900",
         "vote_id": "3871",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4053": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004053",
         "vote_id": "3872",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2372": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002372",
         "vote_id": "3873",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4304": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004304",
         "vote_id": "3876",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4282": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004282",
         "vote_id": "3878",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3675": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003675",
         "vote_id": "3879",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0274/AN/782": {
         "amendement_id": "AMANR5L16PO791932B0274P0D1N000782",
         "vote_id": "388",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26463"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3221": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003221",
         "vote_id": "3880",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1607": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001607",
         "vote_id": "3881",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28367"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/77": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000077",
         "vote_id": "3882",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5467": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005467",
         "vote_id": "3883",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3573": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003573",
         "vote_id": "3884",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1958": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001958",
         "vote_id": "3885",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4206": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004206",
         "vote_id": "3886",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1618": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001618",
         "vote_id": "3887",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1656": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001656",
         "vote_id": "3888",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4517": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004517",
         "vote_id": "3889",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3106": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003106",
         "vote_id": "3890",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2670": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002670",
         "vote_id": "3891",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/160": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000160",
         "vote_id": "3892",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3111": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003111",
         "vote_id": "3893",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28368"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3837": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003837",
         "vote_id": "3895",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1511": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001511",
         "vote_id": "3896",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1021": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001021",
         "vote_id": "3897",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3752": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003752",
         "vote_id": "3898",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3838": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003838",
         "vote_id": "3899",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000095",
         "vote_id": "39",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1320": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001320",
         "vote_id": "390",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5436": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005436",
         "vote_id": "3900",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1945": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001945",
         "vote_id": "3901",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3906": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003906",
         "vote_id": "3902",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1963": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001963",
         "vote_id": "3903",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1621": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001621",
         "vote_id": "3904",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28369"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4125": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004125",
         "vote_id": "3905",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3125": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003125",
         "vote_id": "3906",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2447": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002447",
         "vote_id": "3907",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2463": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002463",
         "vote_id": "3908",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3844": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003844",
         "vote_id": "3909",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1313": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001313",
         "vote_id": "391",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1620": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001620",
         "vote_id": "3910",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2707": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002707",
         "vote_id": "3911",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1619": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001619",
         "vote_id": "3912",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4451": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004451",
         "vote_id": "3913",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5560": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005560",
         "vote_id": "3915",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5572": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005572",
         "vote_id": "3916",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5564": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005564",
         "vote_id": "3917",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5547": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005547",
         "vote_id": "3918",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5466": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005466",
         "vote_id": "3919",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1796": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001796",
         "vote_id": "392",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5589": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005589",
         "vote_id": "3920",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5465": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005465",
         "vote_id": "3921",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28370"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4418": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004418",
         "vote_id": "3922",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28371"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4020": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004020",
         "vote_id": "3923",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28371"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000124",
         "vote_id": "3924",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3574": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003574",
         "vote_id": "3925",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3835": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003835",
         "vote_id": "3926",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3834": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003834",
         "vote_id": "3927",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5584": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005584",
         "vote_id": "3929",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1316": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001316",
         "vote_id": "393",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2325": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002325",
         "vote_id": "3930",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2320": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002320",
         "vote_id": "3931",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3819": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003819",
         "vote_id": "3932",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1640": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001640",
         "vote_id": "3933",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4227": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004227",
         "vote_id": "3936",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28372"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5452": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005452",
         "vote_id": "3939",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1312": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001312",
         "vote_id": "394",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5458": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005458",
         "vote_id": "3940",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5481": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005481",
         "vote_id": "3941",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5482": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005482",
         "vote_id": "3942",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/5483": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N005483",
         "vote_id": "3943",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4452": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004452",
         "vote_id": "3944",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3409": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003409",
         "vote_id": "3945",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3410": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003410",
         "vote_id": "3946",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/4123": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N004123",
         "vote_id": "3947",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2955": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002955",
         "vote_id": "3948",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3954": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003954",
         "vote_id": "3949",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1323": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001323",
         "vote_id": "395",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/92": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000092",
         "vote_id": "3950",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3193": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003193",
         "vote_id": "3951",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1188": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001188",
         "vote_id": "3952",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1191": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001191",
         "vote_id": "3953",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3215": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003215",
         "vote_id": "3954",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/2959": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N002959",
         "vote_id": "3955",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/95": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N000095",
         "vote_id": "3956",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28373"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1321": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001321",
         "vote_id": "396",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3780": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003780",
         "vote_id": "3960",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28374"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/1216": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N001216",
         "vote_id": "3961",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28374"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2600/AN/3778": {
         "amendement_id": "AMANR5L16PO791932BTC2600P0D1N003778",
         "vote_id": "3962",
-        "dossier_id": "DLR5L16N49726"
+        "dossier_id": "DLR5L16N49726",
+        "seance_id": "RUANR5L16S2024IDS28374"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1793": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001793",
         "vote_id": "3964",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28378"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1796": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001796",
         "vote_id": "3965",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28378"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2905": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002905",
         "vote_id": "3967",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000024",
         "vote_id": "3968",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1470": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001470",
         "vote_id": "3969",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1865": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001865",
         "vote_id": "397",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1802": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001802",
         "vote_id": "3970",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28381"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1806": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001806",
         "vote_id": "3972",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2079": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002079",
         "vote_id": "3973",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1905": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001905",
         "vote_id": "3974",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/878": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000878",
         "vote_id": "3976",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3445": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003445",
         "vote_id": "3978",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3453": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003453",
         "vote_id": "3979",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1318": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001318",
         "vote_id": "398",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3440": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003440",
         "vote_id": "3980",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3454": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003454",
         "vote_id": "3981",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3374": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003374",
         "vote_id": "3982",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28382"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1807": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001807",
         "vote_id": "3983",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/30": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000030",
         "vote_id": "3985",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2121": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002121",
         "vote_id": "3986",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1659": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001659",
         "vote_id": "3987",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2076": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002076",
         "vote_id": "3988",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2115": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002115",
         "vote_id": "3989",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28386"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1319": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001319",
         "vote_id": "399",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2643/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC2643P0D1N000013",
         "vote_id": "3997",
-        "dossier_id": "DLR5L16N49801"
+        "dossier_id": "DLR5L16N49801",
+        "seance_id": "RUANR5L16S2024IDS28385"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2643/AN/14": {
         "amendement_id": "AMANR5L16PO791932BTC2643P0D1N000014",
         "vote_id": "3998",
-        "dossier_id": "DLR5L16N49801"
+        "dossier_id": "DLR5L16N49801",
+        "seance_id": "RUANR5L16S2024IDS28385"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2643/AN/37": {
         "amendement_id": "AMANR5L16PO791932BTC2643P0D1N000037",
         "vote_id": "3999",
-        "dossier_id": "DLR5L16N49801"
+        "dossier_id": "DLR5L16N49801",
+        "seance_id": "RUANR5L16S2024IDS28385"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/943": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000943",
         "vote_id": "40",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1839": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001839",
         "vote_id": "400",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3370": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003370",
         "vote_id": "4002",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28387"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1112": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001112",
         "vote_id": "4003",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28387"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1817": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001817",
         "vote_id": "4004",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28387"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/123": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000123",
         "vote_id": "4005",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28387"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/127": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000127",
         "vote_id": "4006",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1818": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001818",
         "vote_id": "4007",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3003": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003003",
         "vote_id": "4008",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2524": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002524",
         "vote_id": "4009",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1883": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001883",
         "vote_id": "401",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2095": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002095",
         "vote_id": "4010",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1874": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001874",
         "vote_id": "4012",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1826": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001826",
         "vote_id": "4013",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/958": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000958",
         "vote_id": "4014",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28388"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2489": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002489",
         "vote_id": "4015",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2343": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002343",
         "vote_id": "4016",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/700": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000700",
         "vote_id": "4017",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2167": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002167",
         "vote_id": "4018",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28389"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1414": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001414",
         "vote_id": "402",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2181": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002181",
         "vote_id": "4022",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/544": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000544",
         "vote_id": "4023",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/985": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000985",
         "vote_id": "4024",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/133": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000133",
         "vote_id": "4025",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1333": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001333",
         "vote_id": "4026",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28417"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/996": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000996",
         "vote_id": "4027",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/713": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000713",
         "vote_id": "4028",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000048",
         "vote_id": "4029",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1882": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001882",
         "vote_id": "403",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/384": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000384",
         "vote_id": "4030",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/289": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000289",
         "vote_id": "4031",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/49": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000049",
         "vote_id": "4032",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/294": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000294",
         "vote_id": "4033",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/194": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000194",
         "vote_id": "4035",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/136": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000136",
         "vote_id": "4036",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1330": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001330",
         "vote_id": "4037",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000052",
         "vote_id": "4038",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2992": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002992",
         "vote_id": "4039",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1892": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001892",
         "vote_id": "404",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/387": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000387",
         "vote_id": "4040",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/63": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000063",
         "vote_id": "4041",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/925": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000925",
         "vote_id": "4042",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2199": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002199",
         "vote_id": "4043",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000012",
         "vote_id": "4044",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/649": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000649",
         "vote_id": "4045",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/874": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000874",
         "vote_id": "4046",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/546": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000546",
         "vote_id": "4047",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1918": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001918",
         "vote_id": "405",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1891": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001891",
         "vote_id": "406",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/555": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000555",
         "vote_id": "4062",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2853": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002853",
         "vote_id": "4063",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2379": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002379",
         "vote_id": "4064",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/147": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000147",
         "vote_id": "4065",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2467": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002467",
         "vote_id": "4066",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3308": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003308",
         "vote_id": "4068",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28423"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/76": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000076",
         "vote_id": "4069",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1863": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001863",
         "vote_id": "407",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2204": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002204",
         "vote_id": "4070",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3457": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003457",
         "vote_id": "4071",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3513": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003513",
         "vote_id": "4072",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3514": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003514",
         "vote_id": "4073",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3456": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003456",
         "vote_id": "4074",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3515": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003515",
         "vote_id": "4075",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3516": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003516",
         "vote_id": "4076",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2494": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002494",
         "vote_id": "4077",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/203": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000203",
         "vote_id": "4078",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3517": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003517",
         "vote_id": "4079",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1775": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001775",
         "vote_id": "408",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2206": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002206",
         "vote_id": "4080",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/65": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000065",
         "vote_id": "4081",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1246": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001246",
         "vote_id": "4082",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1321": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001321",
         "vote_id": "4083",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000075",
         "vote_id": "4084",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28426"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/156": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000156",
         "vote_id": "4085",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28426"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/252": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000252",
         "vote_id": "4086",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28426"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/825": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000825",
         "vote_id": "4087",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28426"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2212": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002212",
         "vote_id": "4088",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2213": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002213",
         "vote_id": "4089",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1241": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001241",
         "vote_id": "409",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3519": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003519",
         "vote_id": "4090",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3531": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003531",
         "vote_id": "4091",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3532": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003532",
         "vote_id": "4092",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2341": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002341",
         "vote_id": "4093",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2214": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002214",
         "vote_id": "4094",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/913": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000913",
         "vote_id": "4095",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2300": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002300",
         "vote_id": "4096",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/255": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000255",
         "vote_id": "4099",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/756": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000756",
         "vote_id": "41",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1315": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001315",
         "vote_id": "410",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/2134": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N002134",
         "vote_id": "4100",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/845": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000845",
         "vote_id": "4101",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28427"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1864": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001864",
         "vote_id": "4102",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28428"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/1016": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N001016",
         "vote_id": "4103",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28428"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/3204": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N003204",
         "vote_id": "4104",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28428"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/2634/AN/518": {
         "amendement_id": "AMANR5L16PO791932BTC2634P0D1N000518",
         "vote_id": "4105",
-        "dossier_id": "DLR5L16N49744"
+        "dossier_id": "DLR5L16N49744",
+        "seance_id": "RUANR5L16S2024IDS28428"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1913": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001913",
         "vote_id": "411",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1907": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001907",
         "vote_id": "412",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1795": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001795",
         "vote_id": "413",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1900": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001900",
         "vote_id": "414",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1851": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001851",
         "vote_id": "416",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1855": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001855",
         "vote_id": "417",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1854": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001854",
         "vote_id": "418",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1904": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001904",
         "vote_id": "419",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26418"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/938": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000938",
         "vote_id": "42",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1054": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001054",
         "vote_id": "420",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26419"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1037": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001037",
         "vote_id": "424",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1068": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001068",
         "vote_id": "425",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1263": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001263",
         "vote_id": "426",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/179": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000179",
         "vote_id": "427",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/180": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000180",
         "vote_id": "428",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1585": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001585",
         "vote_id": "429",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/844": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000844",
         "vote_id": "43",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1484": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001484",
         "vote_id": "430",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/379": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000379",
         "vote_id": "431",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/894": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000894",
         "vote_id": "432",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26420"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/895": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000895",
         "vote_id": "433",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1502": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001502",
         "vote_id": "434",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1719": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001719",
         "vote_id": "435",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1284": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001284",
         "vote_id": "436",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1285": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001285",
         "vote_id": "437",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/836": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000836",
         "vote_id": "438",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1713": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001713",
         "vote_id": "439",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/94": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000094",
         "vote_id": "44",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26208"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1448": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001448",
         "vote_id": "440",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1018": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001018",
         "vote_id": "441",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1690": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001690",
         "vote_id": "442",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1440": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001440",
         "vote_id": "443",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1712": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001712",
         "vote_id": "444",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1658": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001658",
         "vote_id": "445",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/614": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000614",
         "vote_id": "446",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1557": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001557",
         "vote_id": "447",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/380": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000380",
         "vote_id": "449",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26421"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/728": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000728",
         "vote_id": "450",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1492": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001492",
         "vote_id": "451",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1438": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001438",
         "vote_id": "452",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/715": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000715",
         "vote_id": "453",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/366": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000366",
         "vote_id": "454",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1430": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001430",
         "vote_id": "455",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1140": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001140",
         "vote_id": "456",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/716": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000716",
         "vote_id": "457",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1648": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001648",
         "vote_id": "458",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/724": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000724",
         "vote_id": "459",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1646": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001646",
         "vote_id": "460",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/623": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000623",
         "vote_id": "461",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1667": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001667",
         "vote_id": "462",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1376": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001376",
         "vote_id": "463",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1527": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001527",
         "vote_id": "464",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/719": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000719",
         "vote_id": "465",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1033": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001033",
         "vote_id": "466",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1036": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001036",
         "vote_id": "467",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1100": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001100",
         "vote_id": "468",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1396": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001396",
         "vote_id": "469",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/390": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000390",
         "vote_id": "470",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/389": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000389",
         "vote_id": "471",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1528": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001528",
         "vote_id": "472",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1408": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001408",
         "vote_id": "473",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1377": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001377",
         "vote_id": "474",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/721": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000721",
         "vote_id": "475",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/768": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000768",
         "vote_id": "476",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/769": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000769",
         "vote_id": "477",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/776": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000776",
         "vote_id": "478",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1055": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001055",
         "vote_id": "479",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/770": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000770",
         "vote_id": "480",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1146": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001146",
         "vote_id": "481",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/1507": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N001507",
         "vote_id": "482",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/451": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000451",
         "vote_id": "484",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26422"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/2271": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N002271",
         "vote_id": "487",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/403": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000403",
         "vote_id": "488",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/404": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000404",
         "vote_id": "489",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26424"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/516": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000516",
         "vote_id": "491",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/303": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000303",
         "vote_id": "492",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0273C/AN/345": {
         "amendement_id": "AMANR5L16PO791932B0273P2D1N000345",
         "vote_id": "493",
-        "dossier_id": "DLR5L16N45988"
+        "dossier_id": "DLR5L16N45988",
+        "seance_id": "RUANR5L16S2023IDS26425"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/324": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000324",
         "vote_id": "495",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/306": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000306",
         "vote_id": "496",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/307": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000307",
         "vote_id": "497",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/370": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000370",
         "vote_id": "498",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/45": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000045",
         "vote_id": "499",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/158": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000158",
         "vote_id": "500",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/2": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000002",
         "vote_id": "501",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/292": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000292",
         "vote_id": "502",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26444"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/412": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000412",
         "vote_id": "503",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/337": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000337",
         "vote_id": "504",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/339": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000339",
         "vote_id": "505",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/340": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000340",
         "vote_id": "506",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/152": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000152",
         "vote_id": "507",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/22": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000022",
         "vote_id": "508",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/138": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000138",
         "vote_id": "509",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/343": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000343",
         "vote_id": "510",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/342": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000342",
         "vote_id": "511",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/13": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000013",
         "vote_id": "512",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/14": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000014",
         "vote_id": "513",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/341": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000341",
         "vote_id": "514",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/208": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000208",
         "vote_id": "515",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/194": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000194",
         "vote_id": "516",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/413": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000413",
         "vote_id": "517",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/542": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000542",
         "vote_id": "518",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/414": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000414",
         "vote_id": "519",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26445"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/509": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000509",
         "vote_id": "52",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/352": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000352",
         "vote_id": "520",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/493": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000493",
         "vote_id": "521",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/195": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000195",
         "vote_id": "522",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/322": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000322",
         "vote_id": "523",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/24": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000024",
         "vote_id": "524",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/535": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000535",
         "vote_id": "525",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/533": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000533",
         "vote_id": "526",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/283": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000283",
         "vote_id": "527",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/297": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000297",
         "vote_id": "528",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/570": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000570",
         "vote_id": "529",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/878": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000878",
         "vote_id": "53",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/212": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000212",
         "vote_id": "530",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26434"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/605": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000605",
         "vote_id": "531",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/185": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000185",
         "vote_id": "532",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/350": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000350",
         "vote_id": "533",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/509": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000509",
         "vote_id": "534",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/367": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000367",
         "vote_id": "535",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/426": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000426",
         "vote_id": "536",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/492": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000492",
         "vote_id": "537",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/621": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000621",
         "vote_id": "538",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/487": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000487",
         "vote_id": "539",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/734": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000734",
         "vote_id": "54",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/151": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000151",
         "vote_id": "540",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/77": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000077",
         "vote_id": "541",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/78": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000078",
         "vote_id": "542",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/79": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000079",
         "vote_id": "543",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/502": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000502",
         "vote_id": "544",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/82": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000082",
         "vote_id": "545",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/84": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000084",
         "vote_id": "546",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/359": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000359",
         "vote_id": "547",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/83": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000083",
         "vote_id": "548",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/357": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000357",
         "vote_id": "549",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/339": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000339",
         "vote_id": "55",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/332": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000332",
         "vote_id": "550",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/377": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000377",
         "vote_id": "551",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/391": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000391",
         "vote_id": "552",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/314": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000314",
         "vote_id": "553",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/87": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000087",
         "vote_id": "554",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/333": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000333",
         "vote_id": "555",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0393/AN/392": {
         "amendement_id": "AMANR5L16PO791932B0393P0D1N000392",
         "vote_id": "556",
-        "dossier_id": "DLR5L16N46617"
+        "dossier_id": "DLR5L16N46617",
+        "seance_id": "RUANR5L16S2023IDS26555"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0453/AN/3": {
         "amendement_id": "AMANR5L16PO791932BTC0453P0D1N000003",
         "vote_id": "559",
-        "dossier_id": "DLR5L16N46271"
+        "dossier_id": "DLR5L16N46271",
+        "seance_id": "RUANR5L16S2023IDS26547"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/971": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000971",
         "vote_id": "56",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0453/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC0453P0D1N000002",
         "vote_id": "560",
-        "dossier_id": "DLR5L16N46271"
+        "dossier_id": "DLR5L16N46271",
+        "seance_id": "RUANR5L16S2023IDS26547"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/335": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000335",
         "vote_id": "562",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26548"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/651": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000651",
         "vote_id": "563",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26548"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/36": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000036",
         "vote_id": "564",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26548"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/52": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000052",
         "vote_id": "569",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/993": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000993",
         "vote_id": "57",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/38": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000038",
         "vote_id": "570",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1036": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001036",
         "vote_id": "574",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/761": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000761",
         "vote_id": "575",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26501"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/251": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000251",
         "vote_id": "576",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000056",
         "vote_id": "577",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/880": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000880",
         "vote_id": "578",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/379": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000379",
         "vote_id": "579",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/767": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000767",
         "vote_id": "58",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26211"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/715": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000715",
         "vote_id": "581",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26502"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1230": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001230",
         "vote_id": "583",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26552"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/253": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000253",
         "vote_id": "584",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26552"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/388": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000388",
         "vote_id": "586",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26552"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/767": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000767",
         "vote_id": "587",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26504"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1173": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001173",
         "vote_id": "596",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/635": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000635",
         "vote_id": "597",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/290": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000290",
         "vote_id": "598",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1044": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001044",
         "vote_id": "599",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/77": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000077",
         "vote_id": "6",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/816": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000816",
         "vote_id": "600",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/768": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000768",
         "vote_id": "601",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1276": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001276",
         "vote_id": "602",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26505"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/687": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000687",
         "vote_id": "605",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1189": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001189",
         "vote_id": "606",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26506"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/1190": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N001190",
         "vote_id": "607",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26549"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/717": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000717",
         "vote_id": "608",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26550"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/276": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000276",
         "vote_id": "609",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26550"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/415": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000415",
         "vote_id": "610",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26550"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/293": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000293",
         "vote_id": "611",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/786": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000786",
         "vote_id": "612",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/736": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000736",
         "vote_id": "613",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/551": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000551",
         "vote_id": "614",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/600": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000600",
         "vote_id": "615",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0436/AN/334": {
         "amendement_id": "AMANR5L16PO791932BTC0436P0D1N000334",
         "vote_id": "616",
-        "dossier_id": "DLR5L16N46269"
+        "dossier_id": "DLR5L16N46269",
+        "seance_id": "RUANR5L16S2023IDS26551"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0480/AN/413": {
         "amendement_id": "AMANR5L16PO791932B0480P0D1N000413",
         "vote_id": "619",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26537"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0480/AN/194": {
         "amendement_id": "AMANR5L16PO791932B0480P0D1N000194",
         "vote_id": "620",
-        "dossier_id": "DLR5L16N46347"
+        "dossier_id": "DLR5L16N46347",
+        "seance_id": "RUANR5L16S2023IDS26537"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0488/AN/48": {
         "amendement_id": "AMANR5L16PO791932BTC0488P0D1N000048",
         "vote_id": "625",
-        "dossier_id": "DLR5L16N46412"
+        "dossier_id": "DLR5L16N46412",
+        "seance_id": "RUANR5L16S2023IDS26543"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0488/AN/588": {
         "amendement_id": "AMANR5L16PO791932BTC0488P0D1N000588",
         "vote_id": "627",
-        "dossier_id": "DLR5L16N46412"
+        "dossier_id": "DLR5L16N46412",
+        "seance_id": "RUANR5L16S2023IDS26543"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0488/AN/231": {
         "amendement_id": "AMANR5L16PO791932BTC0488P0D1N000231",
         "vote_id": "628",
-        "dossier_id": "DLR5L16N46412"
+        "dossier_id": "DLR5L16N46412",
+        "seance_id": "RUANR5L16S2023IDS26543"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0144/AN/214": {
         "amendement_id": "AMANR5L16PO791932BTC0144P0D1N000214",
         "vote_id": "63",
-        "dossier_id": "DLR5L16N45942"
+        "dossier_id": "DLR5L16N45942",
+        "seance_id": "RUANR5L16S2022IDS26210"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0322/AN/42": {
         "amendement_id": "AMANR5L16PO791932B0322P0D1N000042",
         "vote_id": "631",
-        "dossier_id": "DLR5L16N46428"
+        "dossier_id": "DLR5L16N46428",
+        "seance_id": "RUANR5L16S2023IDS26545"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/203": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000203",
         "vote_id": "637",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/120": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000120",
         "vote_id": "638",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/121": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000121",
         "vote_id": "640",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/122": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000122",
         "vote_id": "641",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/191": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000191",
         "vote_id": "642",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000056",
         "vote_id": "643",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26559"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/137": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000137",
         "vote_id": "644",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26560"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/96": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000096",
         "vote_id": "645",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26560"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/124": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000124",
         "vote_id": "646",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26560"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/111": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000111",
         "vote_id": "647",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26560"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0354/AN/117": {
         "amendement_id": "AMANR5L16PO791932B0354P0D1N000117",
         "vote_id": "655",
-        "dossier_id": "DLR5L16N46473"
+        "dossier_id": "DLR5L16N46473",
+        "seance_id": "RUANR5L16S2023IDS26563"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0352/AN/6": {
         "amendement_id": "AMANR5L16PO791932B0352P0D1N000006",
         "vote_id": "656",
-        "dossier_id": "DLR5L16N46471"
+        "dossier_id": "DLR5L16N46471",
+        "seance_id": "RUANR5L16S2023IDS26564"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0491/AN/71": {
         "amendement_id": "AMANR5L16PO791932BTC0491P0D1N000071",
         "vote_id": "660",
-        "dossier_id": "DLR5L16N46484"
+        "dossier_id": "DLR5L16N46484",
+        "seance_id": "RUANR5L16S2023IDS26566"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3039": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003039",
         "vote_id": "665",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26598"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2863": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002863",
         "vote_id": "666",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/180": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000180",
         "vote_id": "667",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1411": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001411",
         "vote_id": "669",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26600"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1412": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001412",
         "vote_id": "672",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1610": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001610",
         "vote_id": "673",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/798": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000798",
         "vote_id": "675",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000028",
         "vote_id": "676",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/26": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000026",
         "vote_id": "677",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/713": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000713",
         "vote_id": "678",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1445": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001445",
         "vote_id": "679",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/54": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000054",
         "vote_id": "680",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/530": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000530",
         "vote_id": "681",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2170": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002170",
         "vote_id": "682",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1651": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001651",
         "vote_id": "683",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1533": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001533",
         "vote_id": "684",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26601"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2078": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002078",
         "vote_id": "686",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/330": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000330",
         "vote_id": "687",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/566": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000566",
         "vote_id": "688",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1416": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001416",
         "vote_id": "689",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2424": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002424",
         "vote_id": "690",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2419": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002419",
         "vote_id": "691",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2702": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002702",
         "vote_id": "692",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1378": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001378",
         "vote_id": "693",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2189": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002189",
         "vote_id": "694",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26602"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3091": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003091",
         "vote_id": "695",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3088": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003088",
         "vote_id": "696",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3096": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003096",
         "vote_id": "697",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3113": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003113",
         "vote_id": "698",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3120": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003120",
         "vote_id": "699",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/117": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000117",
         "vote_id": "7",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3114": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003114",
         "vote_id": "700",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3145": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003145",
         "vote_id": "701",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2200": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002200",
         "vote_id": "702",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1419": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001419",
         "vote_id": "703",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/554": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000554",
         "vote_id": "704",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3149": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003149",
         "vote_id": "705",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3152": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003152",
         "vote_id": "706",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2429": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002429",
         "vote_id": "707",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2430": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002430",
         "vote_id": "708",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2886": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002886",
         "vote_id": "709",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26604"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/614": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000614",
         "vote_id": "710",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/870": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000870",
         "vote_id": "711",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/867": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000867",
         "vote_id": "712",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/868": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000868",
         "vote_id": "713",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26605"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2443": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002443",
         "vote_id": "717",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2444": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002444",
         "vote_id": "718",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2452": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002452",
         "vote_id": "720",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2448": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002448",
         "vote_id": "721",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/58": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000058",
         "vote_id": "722",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2453": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002453",
         "vote_id": "723",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/233": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000233",
         "vote_id": "726",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2469": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002469",
         "vote_id": "727",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26607"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1230": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001230",
         "vote_id": "728",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/894": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000894",
         "vote_id": "729",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/893": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000893",
         "vote_id": "730",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1363": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001363",
         "vote_id": "731",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2463": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002463",
         "vote_id": "732",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2462": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002462",
         "vote_id": "733",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2464": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002464",
         "vote_id": "734",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2465": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002465",
         "vote_id": "735",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2884": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002884",
         "vote_id": "737",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1791": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001791",
         "vote_id": "738",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2474": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002474",
         "vote_id": "739",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1892": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001892",
         "vote_id": "740",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1851": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001851",
         "vote_id": "741",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2081": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002081",
         "vote_id": "742",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26608"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2874": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002874",
         "vote_id": "745",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3045": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003045",
         "vote_id": "746",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1869": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001869",
         "vote_id": "747",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2080": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002080",
         "vote_id": "748",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2479": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002479",
         "vote_id": "749",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1332": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001332",
         "vote_id": "750",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1538": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001538",
         "vote_id": "751",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2265": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002265",
         "vote_id": "752",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/560": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000560",
         "vote_id": "753",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/209": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000209",
         "vote_id": "754",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1796": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001796",
         "vote_id": "755",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2067": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002067",
         "vote_id": "756",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1547": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001547",
         "vote_id": "758",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26617"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1465": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001465",
         "vote_id": "759",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1801": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001801",
         "vote_id": "760",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1542": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001542",
         "vote_id": "761",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1463": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001463",
         "vote_id": "762",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/56": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000056",
         "vote_id": "764",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1985": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001985",
         "vote_id": "765",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26618"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/585": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000585",
         "vote_id": "766",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2374": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002374",
         "vote_id": "767",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3205": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003205",
         "vote_id": "768",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/146": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000146",
         "vote_id": "770",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2506": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002506",
         "vote_id": "771",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2510": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002510",
         "vote_id": "772",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1559": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001559",
         "vote_id": "773",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2766": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002766",
         "vote_id": "775",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3033": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003033",
         "vote_id": "778",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1286": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001286",
         "vote_id": "779",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26619"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2483": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002483",
         "vote_id": "781",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/247": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000247",
         "vote_id": "782",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/612": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000612",
         "vote_id": "783",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1982": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001982",
         "vote_id": "784",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1105": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001105",
         "vote_id": "785",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/604": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000604",
         "vote_id": "786",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/609": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000609",
         "vote_id": "787",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2482": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002482",
         "vote_id": "788",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26638"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/714": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000714",
         "vote_id": "789",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3227": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003227",
         "vote_id": "790",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3228": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003228",
         "vote_id": "791",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3229": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003229",
         "vote_id": "792",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3235": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003235",
         "vote_id": "793",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2996": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002996",
         "vote_id": "794",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2999": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002999",
         "vote_id": "795",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2481": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002481",
         "vote_id": "797",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26639"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/948": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000948",
         "vote_id": "799",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/177": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000177",
         "vote_id": "8",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000010",
         "vote_id": "801",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2527": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002527",
         "vote_id": "802",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2529": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002529",
         "vote_id": "803",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2533": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002533",
         "vote_id": "804",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2531": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002531",
         "vote_id": "805",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/911": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000911",
         "vote_id": "807",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/413": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000413",
         "vote_id": "809",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26640"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2539": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002539",
         "vote_id": "810",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26624"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1708": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001708",
         "vote_id": "814",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26624"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/3220": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N003220",
         "vote_id": "815",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26624"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2471": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002471",
         "vote_id": "816",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26624"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1782": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001782",
         "vote_id": "817",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26641"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/2975": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N002975",
         "vote_id": "818",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26641"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/1213": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N001213",
         "vote_id": "819",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26641"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/806": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000806",
         "vote_id": "82",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/556": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000556",
         "vote_id": "820",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26641"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0526/AN/742": {
         "amendement_id": "AMANR5L16PO791932BTC0526P0D1N000742",
         "vote_id": "821",
-        "dossier_id": "DLR5L16N46539"
+        "dossier_id": "DLR5L16N46539",
+        "seance_id": "RUANR5L16S2023IDS26641"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0578/AN/26": {
         "amendement_id": "AMANR5L16PO791932B0578P0D1N000026",
         "vote_id": "825",
-        "dossier_id": "DLR5L16N46760"
+        "dossier_id": "DLR5L16N46760",
+        "seance_id": "RUANR5L16S2023IDS26684"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0257/AN/25": {
         "amendement_id": "AMANR5L16PO791932B0257P0D1N000025",
         "vote_id": "828",
-        "dossier_id": "DLR5L16N46275"
+        "dossier_id": "DLR5L16N46275",
+        "seance_id": "RUANR5L16S2023IDS26685"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/913": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000913",
         "vote_id": "83",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0617/AN/75": {
         "amendement_id": "AMANR5L16PO791932BTC0617P0D1N000075",
         "vote_id": "832",
-        "dossier_id": "DLR5L16N46270"
+        "dossier_id": "DLR5L16N46270",
+        "seance_id": "RUANR5L16S2023IDS26687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0617/AN/78": {
         "amendement_id": "AMANR5L16PO791932BTC0617P0D1N000078",
         "vote_id": "833",
-        "dossier_id": "DLR5L16N46270"
+        "dossier_id": "DLR5L16N46270",
+        "seance_id": "RUANR5L16S2023IDS26687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0617/AN/66": {
         "amendement_id": "AMANR5L16PO791932BTC0617P0D1N000066",
         "vote_id": "834",
-        "dossier_id": "DLR5L16N46270"
+        "dossier_id": "DLR5L16N46270",
+        "seance_id": "RUANR5L16S2023IDS26687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0617/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC0617P0D1N000013",
         "vote_id": "835",
-        "dossier_id": "DLR5L16N46270"
+        "dossier_id": "DLR5L16N46270",
+        "seance_id": "RUANR5L16S2023IDS26687"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/166": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000166",
         "vote_id": "84",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26240"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0614/AN/2": {
         "amendement_id": "AMANR5L16PO791932BTC0614P0D1N000002",
         "vote_id": "841",
-        "dossier_id": "DLR5L16N46824"
+        "dossier_id": "DLR5L16N46824",
+        "seance_id": "RUANR5L16S2023IDS26690"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/24": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000024",
         "vote_id": "845",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000028",
         "vote_id": "847",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000027",
         "vote_id": "848",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/1": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000001",
         "vote_id": "849",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/636": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000636",
         "vote_id": "85",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/13": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000013",
         "vote_id": "850",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/74": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000074",
         "vote_id": "851",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/78": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000078",
         "vote_id": "852",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/5": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000005",
         "vote_id": "853",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/60": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000060",
         "vote_id": "854",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/40": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000040",
         "vote_id": "855",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/41": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000041",
         "vote_id": "856",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/72": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000072",
         "vote_id": "858",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/518": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000518",
         "vote_id": "86",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0684/AN/69": {
         "amendement_id": "AMANR5L16PO791932BTC0684P0D1N000069",
         "vote_id": "860",
-        "dossier_id": "DLR5L16N46750"
+        "dossier_id": "DLR5L16N46750",
+        "seance_id": "RUANR5L16S2023IDS26691"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/359": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000359",
         "vote_id": "864",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/396": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000396",
         "vote_id": "865",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/70": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000070",
         "vote_id": "866",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26692"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/397": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000397",
         "vote_id": "868",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/16": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000016",
         "vote_id": "87",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/390": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000390",
         "vote_id": "870",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/391": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000391",
         "vote_id": "872",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/438": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000438",
         "vote_id": "873",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0680/AN/441": {
         "amendement_id": "AMANR5L16PO791932BTC0680P0D1N000441",
         "vote_id": "874",
-        "dossier_id": "DLR5L16N46486"
+        "dossier_id": "DLR5L16N46486",
+        "seance_id": "RUANR5L16S2023IDS26693"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0748/AN/61": {
         "amendement_id": "AMANR5L16PO791932BTC0748P0D1N000061",
         "vote_id": "877",
-        "dossier_id": "DLR5L16N46734"
+        "dossier_id": "DLR5L16N46734",
+        "seance_id": "RUANR5L16S2023IDS26737"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/575": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000575",
         "vote_id": "88",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0748/AN/20": {
         "amendement_id": "AMANR5L16PO791932BTC0748P0D1N000020",
         "vote_id": "886",
-        "dossier_id": "DLR5L16N46734"
+        "dossier_id": "DLR5L16N46734",
+        "seance_id": "RUANR5L16S2023IDS26738"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0748/AN/6": {
         "amendement_id": "AMANR5L16PO791932BTC0748P0D1N000006",
         "vote_id": "887",
-        "dossier_id": "DLR5L16N46734"
+        "dossier_id": "DLR5L16N46734",
+        "seance_id": "RUANR5L16S2023IDS26738"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/2": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000002",
         "vote_id": "89",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0763/AN/28": {
         "amendement_id": "AMANR5L16PO791932BTC0763P0D1N000028",
         "vote_id": "899",
-        "dossier_id": "DLR5L16N46965"
+        "dossier_id": "DLR5L16N46965",
+        "seance_id": "RUANR5L16S2023IDS26758"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0014/AN/37": {
         "amendement_id": "AMANR5L16PO791932BTC0014P0D1N000037",
         "vote_id": "9",
-        "dossier_id": "DLR5L16N45927"
+        "dossier_id": "DLR5L16N45927",
+        "seance_id": "RUANR5L16S2022IDS26201"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/929": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000929",
         "vote_id": "90",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0763/AN/27": {
         "amendement_id": "AMANR5L16PO791932BTC0763P0D1N000027",
         "vote_id": "900",
-        "dossier_id": "DLR5L16N46965"
+        "dossier_id": "DLR5L16N46965",
+        "seance_id": "RUANR5L16S2023IDS26758"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0763/AN/8": {
         "amendement_id": "AMANR5L16PO791932BTC0763P0D1N000008",
         "vote_id": "901",
-        "dossier_id": "DLR5L16N46965"
+        "dossier_id": "DLR5L16N46965",
+        "seance_id": "RUANR5L16S2023IDS26758"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0763/AN/18": {
         "amendement_id": "AMANR5L16PO791932BTC0763P0D1N000018",
         "vote_id": "902",
-        "dossier_id": "DLR5L16N46965"
+        "dossier_id": "DLR5L16N46965",
+        "seance_id": "RUANR5L16S2023IDS26758"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0017/AN/297": {
         "amendement_id": "AMANR5L16PO791932B0017P0D1N000297",
         "vote_id": "91",
-        "dossier_id": "DLR5L16N45943"
+        "dossier_id": "DLR5L16N45943",
+        "seance_id": "RUANR5L16S2022IDS26241"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/684": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000684",
         "vote_id": "914",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26781"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/17533": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N017533",
         "vote_id": "915",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/18063": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N018063",
         "vote_id": "916",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/697": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000697",
         "vote_id": "917",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/17470": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N017470",
         "vote_id": "918",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/17529": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N017529",
         "vote_id": "919",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/435": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000435",
         "vote_id": "920",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/686": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000686",
         "vote_id": "921",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26782"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/687": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000687",
         "vote_id": "922",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26783"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0803/AN/10": {
         "amendement_id": "AMANR5L16PO791932BTC0803P0D1N000010",
         "vote_id": "923",
-        "dossier_id": "DLR5L16N46900"
+        "dossier_id": "DLR5L16N46900",
+        "seance_id": "RUANR5L16S2023IDS26784"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0805/AN/11": {
         "amendement_id": "AMANR5L16PO791932BTC0805P0D1N000011",
         "vote_id": "925",
-        "dossier_id": "DLR5L16N46858"
+        "dossier_id": "DLR5L16N46858",
+        "seance_id": "RUANR5L16S2023IDS26784"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0805/AN/19": {
         "amendement_id": "AMANR5L16PO791932BTC0805P0D1N000019",
         "vote_id": "926",
-        "dossier_id": "DLR5L16N46858"
+        "dossier_id": "DLR5L16N46858",
+        "seance_id": "RUANR5L16S2023IDS26784"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0803/AN/9": {
         "amendement_id": "AMANR5L16PO791932BTC0803P0D1N000009",
         "vote_id": "928",
-        "dossier_id": "DLR5L16N46900"
+        "dossier_id": "DLR5L16N46900",
+        "seance_id": "RUANR5L16S2023IDS26784"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0805/AN/12": {
         "amendement_id": "AMANR5L16PO791932BTC0805P0D1N000012",
         "vote_id": "930",
-        "dossier_id": "DLR5L16N46858"
+        "dossier_id": "DLR5L16N46858",
+        "seance_id": "RUANR5L16S2023IDS26784"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0800/AN/35": {
         "amendement_id": "AMANR5L16PO791932BTC0800P0D1N000035",
         "vote_id": "936",
-        "dossier_id": "DLR5L16N46864"
+        "dossier_id": "DLR5L16N46864",
+        "seance_id": "RUANR5L16S2023IDS26786"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1047": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001047",
         "vote_id": "939",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1049": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001049",
         "vote_id": "940",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1050": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001050",
         "vote_id": "941",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1051": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001051",
         "vote_id": "942",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1053": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001053",
         "vote_id": "943",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1054": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001054",
         "vote_id": "944",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1055": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001055",
         "vote_id": "945",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1088": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001088",
         "vote_id": "946",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19661": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019661",
         "vote_id": "948",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26787"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16733": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016733",
         "vote_id": "953",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/737": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000737",
         "vote_id": "954",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1098": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001098",
         "vote_id": "955",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/50": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000050",
         "vote_id": "956",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/746": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000746",
         "vote_id": "957",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/14104": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N014104",
         "vote_id": "958",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/14172": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N014172",
         "vote_id": "959",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26790"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/738": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000738",
         "vote_id": "960",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26791"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/422": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000422",
         "vote_id": "961",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26791"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/580": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000580",
         "vote_id": "962",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26791"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/14629": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N014629",
         "vote_id": "963",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26791"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/809": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000809",
         "vote_id": "967",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26793"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19138": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019138",
         "vote_id": "968",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26793"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/113": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000113",
         "vote_id": "969",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26793"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/436": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000436",
         "vote_id": "970",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26793"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19727": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019727",
         "vote_id": "971",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26793"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1513": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001513",
         "vote_id": "973",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1523": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001523",
         "vote_id": "974",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/15638": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N015638",
         "vote_id": "975",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/1524": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N001524",
         "vote_id": "976",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/636": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000636",
         "vote_id": "977",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/637": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N000637",
         "vote_id": "978",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2811": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002811",
         "vote_id": "979",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16625": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016625",
         "vote_id": "980",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26794"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3129": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003129",
         "vote_id": "981",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16464": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016464",
         "vote_id": "982",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19879": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019879",
         "vote_id": "984",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/16634": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N016634",
         "vote_id": "985",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2812": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002812",
         "vote_id": "986",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3130": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003130",
         "vote_id": "987",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/19834": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N019834",
         "vote_id": "988",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26795"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/2813": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N002813",
         "vote_id": "989",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3112": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003112",
         "vote_id": "990",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/5302": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N005302",
         "vote_id": "991",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3103": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003103",
         "vote_id": "992",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4506": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004506",
         "vote_id": "993",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/10731": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N010731",
         "vote_id": "994",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4508": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004508",
         "vote_id": "995",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/6600": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N006600",
         "vote_id": "996",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/6642": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N006642",
         "vote_id": "997",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/4695": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N004695",
         "vote_id": "998",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     },
     "https://www.assemblee-nationale.fr/dyn/16/amendements/0760/AN/3114": {
         "amendement_id": "AMANR5L16PO791932B0760P0D1N003114",
         "vote_id": "999",
-        "dossier_id": "DLR5L16N47066"
+        "dossier_id": "DLR5L16N47066",
+        "seance_id": "RUANR5L16S2023IDS26796"
     }
 }

--- a/data/openai.js
+++ b/data/openai.js
@@ -1,8 +1,26 @@
-import OpenAI from "openai";
+import { OllamaEmbeddings } from "@langchain/community/embeddings/ollama";
+import { HNSWLib } from "@langchain/community/vectorstores/hnswlib";
+import { OpenAIEmbeddings } from "@langchain/openai";
 import "dotenv/config";
 import { backOff } from "exponential-backoff";
+import OpenAI from "openai";
 
-const openai = new OpenAI();
+const aiConfig = {
+  "ollama": {
+    openai: new OpenAI({ baseURL: 'http://localhost:11434/v1', }),
+    embeddings: new OllamaEmbeddings({ model: "nomic-embed-text:latest" }),
+    chatModel: "llama3:latest",
+    vsdirectory: "ollama_outputs"
+  },
+  "openai": {
+    openai: new OpenAI(),
+    embeddings: new OpenAIEmbeddings({ model: "text-embedding-3-small" }),
+    chatModel: "gpt-4o",
+    vsdirectory: "openai_outputs"
+  }
+};
+const { openai, embeddings, chatModel, vsdirectory } = aiConfig.openai;
+const vectorStore = await HNSWLib.load(vsdirectory, embeddings)
 
 export const summarize = async (content) => {
   if (!content) return
@@ -12,9 +30,9 @@ export const summarize = async (content) => {
         messages: [
           {
             role: "system",
-            content: `Résumes en francais le contenu de cette loi (ou amendement) à l'assemblée nationale francaise. 
-        Sois précis et pas trop général. Utilises des mots faciles à comprendre. 
-        Pas de phrases consensuelles, parles d'actions concrètes. Sois synthétique, ne mentionne pas le parlement ou le type de texte. 
+            content: `Résumes en francais le contenu de cette loi (ou amendement) à l'assemblée nationale francaise.
+        Sois précis et pas trop général. Utilises des mots faciles à comprendre.
+        Pas de phrases consensuelles, parles d'actions concrètes. Sois synthétique, ne mentionne pas le parlement ou le type de texte.
 
         titre: Objectif de la loi. Moins de 30 mots.
         sous_titre_1: Contexte de la loi. Moins de 60 mots.
@@ -26,7 +44,7 @@ export const summarize = async (content) => {
             "sous_titre_1": "",
             "sous_titre_2": ""
         }
-        
+
         Ecris dans le même style que ces exemples :
         {
             "titre": "Assouplir la réglementation du glyphosate",
@@ -46,7 +64,7 @@ export const summarize = async (content) => {
             content: content.slice(0, 20000 * 4),
           },
         ],
-        model: "gpt-4o",
+        model: chatModel,
         response_format: { type: "json_object" },
       }),
     {
@@ -61,3 +79,57 @@ export const summarize = async (content) => {
   return data;
 };
 
+export const argue = async (subject) => {
+  const completion = await backOff(
+    async () => {
+      const retrievedDocs = await vectorStore.similaritySearch(subject, 5)
+      const context = retrievedDocs.map((doc) => doc.pageContent).join("\n\n")
+      const completion = await openai.chat.completions.create({
+        messages: [
+          {
+            role: "system",
+            content: `Extrais les arguments pour et contre du contexte fourni qui est issu de débats à l'assemblée nationale.
+                      Paraphrases les arguments des députés.
+                      Sois précis et pas trop général. Utilises des mots faciles à comprendre.
+                      Pas de phrases consensuelles, parles de faits concrètes.
+
+                      pour: Arguments pour. Moins de 4 arguments.
+                      contre: Arguments contre. Moins de 4 arguments.
+
+                      Résumes la loi dans le format JSON suivant:
+                      {
+                          "pour": "",
+                          "contre": "",
+                      }
+                      Ecris dans le même style que cet exemple (interdiction du glyphosate) :
+                      {
+                          "pour": "Ce pesticide est dangereux pour la nature. Il est reconnu comme « probablement cancérigène » par l'OMS. Écotoxique, il contamine les sols, l'air et l'eau, affectant gravement la biodiversité.",
+                          "contre": "Pour s'en passer, il serait nécessaire de changer nos pratiques culturales. Cela mettrait nos agriculteurs en difficulté"
+                      }
+                      `,
+          },
+          {
+            role: "user",
+            content: `Sujet: ${subject}
+
+                      contexte:
+                      ${context}
+                      `,
+          },
+        ],
+        model: chatModel,
+        response_format: { type: "json_object" },
+      })
+      return completion
+    },
+    {
+      retry: (e) => {
+        console.log(e);
+        if (e.status == 429) return true;
+        return false
+      },
+    }
+  );
+  const data = JSON.parse(completion.choices[0].message.content);
+  return data;
+};

--- a/data/package.json
+++ b/data/package.json
@@ -5,16 +5,20 @@
   "license": "MIT",
   "type": "module",
   "dependencies": {
+    "@langchain/community": "^0.2.17",
     "array-deluxe": "^1.0.15",
     "csv": "^6.3.9",
     "dotenv": "^16.4.5",
     "exponential-backoff": "^3.1.1",
     "fast-xml-parser": "^4.4.0",
+    "hnswlib-node": "^3.0.0",
     "html-entities": "^2.5.2",
+    "langchain": "^0.2.8",
     "node-html-parser": "^6.1.13",
     "openai": "^4.49.1",
     "p-ratelimit": "^1.0.1",
     "pako": "^2.1.0",
+    "pdf-parse": "^1.1.1",
     "pdf-text-reader": "^5.1.0",
     "zlib": "^1.0.5"
   }

--- a/data/seanceid.js
+++ b/data/seanceid.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+const getSeanceId = (dossierId, amendementId) => {
+    const folderPath = `amendements/${dossierId}`;
+    const subFolders = fs.readdirSync(folderPath, 'utf8');
+    let seanceId = null;
+    for (let subFolder of subFolders) {
+        const subFolderPath = path.join(folderPath, subFolder)
+        const stat = fs.statSync(subFolderPath);
+        if (stat.isDirectory()) {
+            const files = fs.readdirSync(subFolderPath, 'utf8')
+            for (let file of files) {
+                if (file == `${amendementId}.json`) {
+                    const filePath = path.join(subFolderPath, file);
+                    const fileContent = fs.readFileSync(filePath, 'utf-8');
+                    const content = JSON.parse(fileContent);
+                    seanceId = content.amendement.seanceDiscussionRef;
+                    return seanceId;
+                }
+            }
+        }
+    }
+    return seanceId
+}
+const updateAmendementsUrls = () => {
+    const filePath = 'amendement_urls.json';
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const content = JSON.parse(fileContent)
+    for (let url in content) {
+        const seance_id = getSeanceId(content[url].dossier_id, content[url].amendement_id)
+        content[url].seance_id = seance_id
+    }
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 4), 'utf8');
+    return content;
+};
+
+updateAmendementsUrls();
+console.log("✅ Amendements mis à jour");

--- a/data/sync.js
+++ b/data/sync.js
@@ -1,0 +1,23 @@
+import fs from 'fs';
+
+export const getSheet = async () => {
+    const filePath = 'sheet.json';
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const records = JSON.parse(fileContent);
+    return records;
+};
+
+export const getVoteId = (url) => {
+    const parts = url.split('/');
+    const id = parts[parts.length - 1]
+    return id;
+};
+
+const getAmendementsUrls = () => {
+    const filePath = 'amendement_urls.json';
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const content = JSON.parse(fileContent)
+    return content;
+};
+
+export const amendement_urls = getAmendementsUrls();

--- a/data/vectorstore.js
+++ b/data/vectorstore.js
@@ -1,0 +1,58 @@
+import { OllamaEmbeddings } from "@langchain/community/embeddings/ollama";
+import { HNSWLib } from "@langchain/community/vectorstores/hnswlib";
+import http from "http";
+import https from "https";
+import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { readPdfText } from "pdf-text-reader";
+import { amendement_urls } from "./sync.js";
+
+const getFinalPdfUrl = async (seanceUrl) => {
+    return new Promise((resolve, reject) => {
+        const parsedUrl = new URL(seanceUrl);
+        const options = {
+            hostname: parsedUrl.hostname,
+            path: parsedUrl.pathname + parsedUrl.search,
+            method: 'HEAD',
+        };
+
+        const client = parsedUrl.protocol === 'https:' ? https : http;
+
+        const request = client.request(options, response => {
+            if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+                parsedUrl.pathname = response.headers.location
+            }
+            resolve(`${parsedUrl.toString()}.pdf`)
+        });
+        request.on('error', error => {
+            console.error('Error fetching final URL:', error);
+            reject(error);
+        });
+        request.end();
+    });
+}
+
+const uniqueIds = new Set(Object.entries(amendement_urls).map(([amendement_url, { seance_id }]) => seance_id))
+const allUrls = await Promise.all(Array.from(uniqueIds).map(x => getFinalPdfUrl(`https://www.assemblee-nationale.fr/dyn/crSeanceRedirect/${x}`)));
+console.log(allUrls)
+
+const splitter = new RecursiveCharacterTextSplitter({
+    chunkSize: 4096,
+    chunkOverlap: 256,
+})
+
+var splitted_texts = [];
+var metadatas = [];
+for (const pdfUrl of allUrls) {
+    const text = await readPdfText({ url: pdfUrl, isEvalSupported: true });
+    const output = await splitter.splitText(text);
+    splitted_texts.push(...output)
+    metadatas.push(...output.map(x => ({ url: pdfUrl })))
+}
+const embeddings = new OllamaEmbeddings({ model: "nomic-embed-text:latest" })
+const vectorStore = await HNSWLib.fromTexts(
+    splitted_texts,
+    metadatas,
+    embeddings
+);
+const directory = "outputs";
+await vectorStore.save(directory);

--- a/data/yarn.lock
+++ b/data/yarn.lock
@@ -2,6 +2,82 @@
 # yarn lockfile v1
 
 
+"@langchain/community@^0.2.17":
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/@langchain/community/-/community-0.2.17.tgz#83e776b5d4d022b22bce907ce08668c56422e8de"
+  integrity sha512-lbmOvOvE0L2EV8lUb/ZcYyrLGF0sveGpYg9A0m6F/nDhuPG1HZqHvU/LiHsCaVO2WJPGowibMPTC02fUG/6dKA==
+  dependencies:
+    "@langchain/core" "~0.2.11"
+    "@langchain/openai" "~0.1.0"
+    binary-extensions "^2.2.0"
+    expr-eval "^2.0.2"
+    flat "^5.0.2"
+    js-yaml "^4.1.0"
+    langchain "0.2.3"
+    langsmith "~0.1.30"
+    uuid "^9.0.0"
+    zod "^3.22.3"
+    zod-to-json-schema "^3.22.5"
+
+"@langchain/core@>0.1.56 <0.3.0", "@langchain/core@>0.2.0 <0.3.0", "@langchain/core@>=0.2.5 <0.3.0", "@langchain/core@>=0.2.8 <0.3.0", "@langchain/core@>=0.2.9 <0.3.0", "@langchain/core@~0.2.0", "@langchain/core@~0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.2.12.tgz#6e7ca72d59f011d5233863d8c2268ccb33adde05"
+  integrity sha512-zaKvUcWU1Cxcpd/fxklygY6iUrxls10KTRzyHZGBAIKJq1JD/B10vX59YlFgBs7nqqVTEvaChfIE0O0e2qBttA==
+  dependencies:
+    ansi-styles "^5.0.0"
+    camelcase "6"
+    decamelize "1.2.0"
+    js-tiktoken "^1.0.12"
+    langsmith "~0.1.30"
+    ml-distance "^4.0.0"
+    mustache "^4.2.0"
+    p-queue "^6.6.2"
+    p-retry "4"
+    uuid "^9.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/openai@>=0.1.0 <0.3.0":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-0.2.1.tgz#2c0c2cb6bd7839d8ce342c97099c6e35f2dde40d"
+  integrity sha512-Ti3C6ZIUPaueIPAfMljMnLu3GSGNq5KmrlHeWkIbrLShOBlzj4xj7mRfR73oWgAC0qivfxdkfbB0e+WCY+oRJw==
+  dependencies:
+    "@langchain/core" ">=0.2.8 <0.3.0"
+    js-tiktoken "^1.0.12"
+    openai "^4.49.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/openai@~0.0.28":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-0.0.34.tgz#36c9bca0721ab9f7e5d40927e7c0429cacbd5b56"
+  integrity sha512-M+CW4oXle5fdoz2T2SwdOef8pl3/1XmUx1vjn2mXUVM/128aO0l23FMF0SNBsAbRV6P+p/TuzjodchJbi0Ht/A==
+  dependencies:
+    "@langchain/core" ">0.1.56 <0.3.0"
+    js-tiktoken "^1.0.12"
+    openai "^4.41.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/openai@~0.1.0":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-0.1.3.tgz#6eb0994e970d85ffa9aaeafb94449024ccf6ca63"
+  integrity sha512-riv/JC9x2A8b7GcHu8sx+mlZJ8KAwSSi231IPTlcciYnKozmrQ5H0vrtiD31fxiDbaRsk7tyCpkSBIOQEo7CyQ==
+  dependencies:
+    "@langchain/core" ">=0.2.5 <0.3.0"
+    js-tiktoken "^1.0.12"
+    openai "^4.49.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+"@langchain/textsplitters@~0.0.0":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@langchain/textsplitters/-/textsplitters-0.0.3.tgz#1a3cc93dd2ab330edb225400ded190a22fea14e3"
+  integrity sha512-cXWgKE3sdWLSqAa8ykbCcUsUF1Kyr5J3HOWYGuobhPEycXW4WI++d5DhzdpL238mzoEXTi90VqfSCra37l5YqA==
+  dependencies:
+    "@langchain/core" ">0.2.0 <0.3.0"
+    js-tiktoken "^1.0.12"
+
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
@@ -39,6 +115,16 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/uuid@^9.0.1":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -70,6 +156,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
@@ -82,6 +173,11 @@ are-we-there-yet@^2.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-deluxe@^1.0.15:
   version "1.0.15"
@@ -98,6 +194,28 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+binary-extensions@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+binary-search@^1.3.5:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.6.tgz#e32426016a0c5092f0f3598836a1c7da3560565c"
+  integrity sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -110,6 +228,11 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+camelcase@6:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 canvas@^2.11.2:
   version "2.11.2"
@@ -136,6 +259,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -194,6 +322,18 @@ debug@4:
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
+
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+decamelize@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
 decompress-response@^4.2.0:
   version "4.2.1"
@@ -267,10 +407,20 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
+expr-eval@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expr-eval/-/expr-eval-2.0.2.tgz#fa6f044a7b0c93fde830954eb9c5b0f7fbc7e201"
+  integrity sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==
 
 fast-xml-parser@^4.4.0:
   version "4.4.0"
@@ -278,6 +428,16 @@ fast-xml-parser@^4.4.0:
   integrity sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==
   dependencies:
     strnum "^1.0.5"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 form-data-encoder@1.7.2:
   version "1.7.2"
@@ -350,6 +510,14 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hnswlib-node@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hnswlib-node/-/hnswlib-node-3.0.0.tgz#0ec5cedf082691a5e2bec7a8faa24f742077cc50"
+  integrity sha512-fypn21qvVORassppC8/qNfZ5KAOspZpm/IbUkAtlqvbtDNnF5VVk5RWF7O5V6qwr7z+T3s1ePej6wQt5wRQ4Cg==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^8.0.0"
+
 html-entities@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.5.2.tgz#201a3cf95d3a15be7099521620d19dfb4f65359f"
@@ -383,10 +551,100 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+is-any-array@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-2.0.1.tgz#9233242a9c098220290aa2ec28f82ca7fa79899e"
+  integrity sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+js-tiktoken@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.12.tgz#af0f5cf58e5e7318240d050c8413234019424211"
+  integrity sha512-L7wURW1fH9Qaext0VzaUDpFGVQgjkdE3Dgsy9/+yXyGEpBKnylTd0mU0bfbNkKDlXRb6TEsZkwuflu1B8uQbJQ==
+  dependencies:
+    base64-js "^1.5.1"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
+jsonpointer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
+
+langchain@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/langchain/-/langchain-0.2.3.tgz#c14bb05cf871b21bd63b84b3ab89580b1d62539f"
+  integrity sha512-T9xR7zd+Nj0oXy6WoYKmZLy0DlQiDLFPGYWdOXDxy+AvqlujoPdVQgDSpdqiOHvAjezrByAoKxoHCz5XMwTP/Q==
+  dependencies:
+    "@langchain/core" "~0.2.0"
+    "@langchain/openai" "~0.0.28"
+    "@langchain/textsplitters" "~0.0.0"
+    binary-extensions "^2.2.0"
+    js-tiktoken "^1.0.12"
+    js-yaml "^4.1.0"
+    jsonpointer "^5.0.1"
+    langchainhub "~0.0.8"
+    langsmith "~0.1.7"
+    ml-distance "^4.0.0"
+    openapi-types "^12.1.3"
+    p-retry "4"
+    uuid "^9.0.0"
+    yaml "^2.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+langchain@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/langchain/-/langchain-0.2.8.tgz#9bd77f5c12071d0ccb637c04fc33415e5369e5aa"
+  integrity sha512-kb2IOMA71xH8e6EXFg0l4S+QSMC/c796pj1+7mPBkR91HHwoyHZhFRrBaZv4tV+Td+Ba91J2uEDBmySklZLpNQ==
+  dependencies:
+    "@langchain/core" ">=0.2.9 <0.3.0"
+    "@langchain/openai" ">=0.1.0 <0.3.0"
+    "@langchain/textsplitters" "~0.0.0"
+    binary-extensions "^2.2.0"
+    js-tiktoken "^1.0.12"
+    js-yaml "^4.1.0"
+    jsonpointer "^5.0.1"
+    langchainhub "~0.0.8"
+    langsmith "~0.1.30"
+    ml-distance "^4.0.0"
+    openapi-types "^12.1.3"
+    p-retry "4"
+    uuid "^9.0.0"
+    yaml "^2.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.22.3"
+
+langchainhub@~0.0.8:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/langchainhub/-/langchainhub-0.0.11.tgz#2ce22def9c84699dcbd4fd4b78270d34bd2a9ae9"
+  integrity sha512-WnKI4g9kU2bHQP136orXr2bcRdgz9iiTBpTN0jWt9IlScUKnJBoD0aa2HOzHURQKeQDnt2JwqVmQ6Depf5uDLQ==
+
+langsmith@~0.1.30, langsmith@~0.1.7:
+  version "0.1.35"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.1.35.tgz#1da388ff5b34fa489dcd45579f5295e792fecfd9"
+  integrity sha512-7GGltg7nWEv2aG8s62M80A8GBTQHl06mKuBy19lmvVaqhfg8Gn+/WD2rGFZsIpL90WuDZjFO/FNnlQ1j3g41yQ==
+  dependencies:
+    "@types/uuid" "^9.0.1"
+    commander "^10.0.1"
+    lodash.set "^4.3.2"
+    p-queue "^6.6.2"
+    p-retry "4"
+    uuid "^9.0.0"
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 make-dir@^3.1.0:
   version "3.1.0"
@@ -444,25 +702,76 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+ml-array-mean@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/ml-array-mean/-/ml-array-mean-1.1.6.tgz#d951a700dc8e3a17b3e0a583c2c64abd0c619c56"
+  integrity sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==
+  dependencies:
+    ml-array-sum "^1.1.6"
+
+ml-array-sum@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/ml-array-sum/-/ml-array-sum-1.1.6.tgz#d1d89c20793cd29c37b09d40e85681aa4515a955"
+  integrity sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==
+  dependencies:
+    is-any-array "^2.0.0"
+
+ml-distance-euclidean@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz#3a668d236649d1b8fec96380b9435c6f42c9a817"
+  integrity sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==
+
+ml-distance@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ml-distance/-/ml-distance-4.0.1.tgz#4741d17a1735888c5388823762271dfe604bd019"
+  integrity sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==
+  dependencies:
+    ml-array-mean "^1.1.6"
+    ml-distance-euclidean "^2.0.0"
+    ml-tree-similarity "^1.0.0"
+
+ml-tree-similarity@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz#24705a107e32829e24d945e87219e892159c53f0"
+  integrity sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==
+  dependencies:
+    binary-search "^1.3.5"
+    num-sort "^2.0.0"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 nan@^2.17.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
+node-addon-api@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.0.0.tgz#5453b7ad59dd040d12e0f1a97a6fa1c765c5c9d2"
+  integrity sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==
+
 node-domexception@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-ensure@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
+  integrity sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -503,6 +812,11 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+num-sort@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/num-sort/-/num-sort-2.1.0.tgz#1cbb37aed071329fdf41151258bc011898577a9b"
+  integrity sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -514,6 +828,20 @@ once@^1.3.0, once@^1.3.1:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+openai@^4.41.1:
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.52.3.tgz#3c6459dfd65e2bf9671729f25879a5b4224dca70"
+  integrity sha512-IyQLYKGYoEEkUCEm2frPzwHDJ3Ym663KtivnY6pWCzuoi6/HgSIMMxpcuTRS81GH6tiULPYGmTxIvzXdmPIWOw==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+    web-streams-polyfill "^3.2.1"
 
 openai@^4.49.1:
   version "4.49.1"
@@ -529,10 +857,43 @@ openai@^4.49.1:
     node-fetch "^2.6.7"
     web-streams-polyfill "^3.2.1"
 
+openapi-types@^12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.1.3.tgz#471995eb26c4b97b7bd356aacf7b91b73e777dd3"
+  integrity sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
+p-queue@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
 p-ratelimit@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/p-ratelimit/-/p-ratelimit-1.0.1.tgz#a07fb2419f9811feb99fb687f97e00aa0244ac3e"
   integrity sha512-tKBGoow6aWRH68K2eQx+qc1gSegjd5VLirZYc1Yms9pPFsYQ9TFI6aMn0vJH2vmvzjNpjlWZOFft4aPUen2w0A==
+
+p-retry@4:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 pako@^2.1.0:
   version "2.1.0"
@@ -548,6 +909,14 @@ path2d@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/path2d/-/path2d-0.2.0.tgz#28bb0e8e6298b2a1adb75ab1b4ffd8c263c28c19"
   integrity sha512-KdPAykQX6kmLSOO6Jpu2KNcCED7CKjmaBNGGNuctOsG0hgYO1OdYQaan6cYXJiG0WmXOwZZPILPBimu5QAIw3A==
+
+pdf-parse@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pdf-parse/-/pdf-parse-1.1.1.tgz#745e07408679548b3995ff896fd38e96e19d14a7"
+  integrity sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==
+  dependencies:
+    debug "^3.1.0"
+    node-ensure "^0.0.0"
 
 pdf-text-reader@^5.1.0:
   version "5.1.0"
@@ -572,6 +941,11 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 rimraf@^3.0.2:
   version "3.0.2"
@@ -679,6 +1053,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 web-streams-polyfill@4.0.0-beta.3:
   version "4.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
@@ -719,7 +1098,22 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^2.2.1:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e"
+  integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
+
 zlib@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
   integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==
+
+zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.22.5:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.23.1.tgz#5225925b8ed5fa20096bd99be076c4b29b53d309"
+  integrity sha512-oT9INvydob1XV0v1d2IadrR74rLtDInLvDFfAa1CG0Pmg/vxATk7I2gSelfj271mbzeM4Da0uuDQE/Nkj3DWNw==
+
+zod@^3.22.3, zod@^3.22.4:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==

--- a/frontend/src/assets/styles/pages/_Votes.scss
+++ b/frontend/src/assets/styles/pages/_Votes.scss
@@ -47,6 +47,15 @@
     justify-content: end;
   }
 
+  &__tooltip {
+    position: absolute;
+    background-color: var(--mui-palette-body-main);
+    color: white;
+    padding: 10px;
+    border-radius: 20px;
+    z-index: 10;
+  }
+
   &__actions {
     display: flex;
     gap: 2rem;

--- a/frontend/src/pages/Votes.jsx
+++ b/frontend/src/pages/Votes.jsx
@@ -39,6 +39,7 @@ export default function Votes() {
           Number(data.votes?.[b]?.pinned || false),
       ),
   );
+  const [tooltipContent, setTooltipContent] = useState(false);
   const handleDismiss = (el, meta, id, action, operation) => {
     if (operation !== "swipe") return;
     setTimeout(() => {
@@ -208,6 +209,12 @@ export default function Votes() {
                 context.choose({ vote_id: id, type: "-" });
               }, 0);
             }}
+            onMouseOver={() => {
+              setTooltipContent(data.votes[id]?.contre || null);
+            }}
+            onMouseOut={() => {
+              setTooltipContent(null);
+            }}
           >
             <ThumbDownIcon color="red" />
           </Button>
@@ -250,9 +257,21 @@ export default function Votes() {
                 context.choose({ vote_id: id, type: "+" });
               }, 0);
             }}
+            onMouseOver={() => {
+              setTooltipContent(data.votes[id]?.pour || null);
+            }}
+            onMouseOut={() => {
+              setTooltipContent(null);
+            }}
           >
             <ThumbUpIcon color="green" />
           </Button>
+          {tooltipContent && <div
+            className="Votes__tooltip"
+            style={{ bottom: actionPourRef.current?.offsetHeight }}
+          >
+            {tooltipContent}
+          </div>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Bonjour,

C'est un super projet ! Je me permets d'ajouter ma pierre à l'édifice: ça peut être intéressant de rajouter du contexte aux votes, notamment les arguments en faveur/contre qui sont soulevés lors des débats à l'assemblée. Souvent, le résumé des amendements/lois n'est pas un contexte suffisant pour décider d'un vote.

Démo de la fonctionnalité ajoutée: https://github.com/arnaudsm/votefinder.fr/assets/102949971/688b7924-abf2-4105-84a5-95762efe557c

N'ayant pas accès à `data/sync.js` ni `data/resumes`, je suis parti de la liste des amendements et j'ai re-généré les fichiers et les votes avec les résumés par IA, et j'ai rajouté les arguments pour/contre (généré par IA en lisant les comptes rendus des séances) ainsi que les liens vers les séances.

Petit tour des modifications:
- arguments en faveur/contre les amendements:
    - ajout automatisé du lien vers les débats ("seance_url" dans `amendements_urls.json`) via `seanceid.js` en utilisant les [données open data de l'assemblée nationale](https://data.assemblee-nationale.fr/archives-xvie/amendements/tous-les-amendements)
    - construction d'une base de données de tous les comptes rendus via `vectorstore.js`
    - utilisation d'un RAG pour extraire les arguments énoncés par les députés lors des débats en pour/contre les amendements (`argue` dans `openai.js` directement utilisée dans `summarize.js`)
    - ajout dans l'application, sous forme de tooltip lorsque l'utilisateur s'apprête à voter une loi.
- ajout de `sync.js` (probablement pas nécessaire)
- mise à jour de `amendement_urls.json`
- choix d'utilisation IA locale (Ollama vs OpenAI)

Exemples des nouveaux votes générés via `node summarize` avec les champs `pour`,`contre`,`seance_url`,`dossier_url` ajoutés:
    - [VTANR5L16V1018.json](https://github.com/user-attachments/files/16100307/VTANR5L16V1018.json)
    - [VTANR5L16V1007.json](https://github.com/user-attachments/files/16100308/VTANR5L16V1007.json)

J'ai aussi les embeddings des séances pour text-embedding-3-small et nomic-embed-text en local si besoin. Il y a encore un peu de travail notamment au niveau de l'UI j'ai fait un truc rapide c'est pas super joli !


